### PR TITLE
Added --ssl-protocol=any to phantomjs command

### DIFF
--- a/src/Spatie/Browsershot/Browsershot.php
+++ b/src/Spatie/Browsershot/Browsershot.php
@@ -161,7 +161,7 @@ class Browsershot {
 
         fwrite($tempJsFileHandle, $fileContent);
         $tempFileName = stream_get_meta_data($tempJsFileHandle)['uri'];
-        $cmd = escapeshellcmd("{$this->binPath} " . $tempFileName);
+        $cmd = escapeshellcmd("{$this->binPath} --ssl-protocol=any " . $tempFileName);
 
         shell_exec($cmd);
 


### PR DESCRIPTION
This fixes a bug where phantomjs will not take a screenshot over https.
Details can be found here: http://stackoverflow.com/a/24679134.