### PR TITLE
Added ignore SSL errors parameter

### DIFF
--- a/src/Spatie/Browsershot/Browsershot.php
+++ b/src/Spatie/Browsershot/Browsershot.php
@@ -161,7 +161,7 @@ class Browsershot {
 
         fwrite($tempJsFileHandle, $fileContent);
         $tempFileName = stream_get_meta_data($tempJsFileHandle)['uri'];
-        $cmd = escapeshellcmd("{$this->binPath} --ssl-protocol=any " . $tempFileName);
+        $cmd = escapeshellcmd("{$this->binPath} --ssl-protocol=any --ignore-ssl-errors=true " . $tempFileName);
 
         shell_exec($cmd);
 


### PR DESCRIPTION
Fixes possible blank screenshots in PhantomJS (e.g. when using SNI)