### PR TITLE
fixed phantomJs timeout setting

### DIFF
--- a/src/Spatie/Browsershot/Browsershot.php
+++ b/src/Spatie/Browsershot/Browsershot.php
@@ -275,6 +275,7 @@ class Browsershot
         return "
             var page = require('webpage').create();
             page.settings.javascriptEnabled = true;
+            page.settings.resourceTimeout = ".$this->timeout.";
             page.viewportSize = { width: ".$this->width.($this->height == 0 ? '' : ', height: '.$this->height)." };
             page.open('{$this->url}', function() {
                 if (".($this->backgroundColor ? 'true' : 'false').") {


### PR DESCRIPTION
Hey,

this settings prevents phantomJs from waiting forever. Had this bug once while creating a screenshot.
This setting solved the bug for me!