### PR TITLE
Update allowed file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ These methods are provided:
 * `setURL()`: Set the URL of the webpage which should be converted to an image
 * `setTimeout()`: Set the browsershot timeout duration in ms required to fully load all page assets and scripts (defaults to 5000).
 * `setBackgroundColor($hexValueOrColorName)`: Set the background color of the html document prior to taking a screenshot.
-* `save($targetFile)`: Starts the conversion-process. The targetfile should have one of these extensions: png, jpg, jpeg.
+* `save($targetFile)`: Starts the conversion-process. The targetfile should have one of these extensions: png, jpg, jpeg, ppm, bmp, pdf, gif.
 
 ## Other implementations
 

--- a/src/Spatie/Browsershot/Browsershot.php
+++ b/src/Spatie/Browsershot/Browsershot.php
@@ -195,7 +195,7 @@ class Browsershot
             throw new Exception('targetfile not set');
         }
 
-        if (! in_array(strtolower(pathinfo($targetFile, PATHINFO_EXTENSION)), ['jpeg', 'jpg', 'png'])) {
+        if (! in_array(strtolower(pathinfo($targetFile, PATHINFO_EXTENSION)), ['jpeg', 'jpg', 'png', 'ppm', 'bmp', 'pdf', 'gif'])) {
             throw new Exception('targetfile extension not valid');
         }
 


### PR DESCRIPTION
There are possible cases when .png and .jpg not enough. Maybe worth allow more flexible settings for this like here http://phantomjs.org/api/webpage/method/render.html ?