### PR TITLE
Added binary for mac

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "intervention/image": "2.*"
     },
     "bin": [
-        "bin/phantomjs"
+        "bin/phantomjs",
+        "bin/phantomjs_macosx"
     ],
     "require-dev": {
         "phpspec/phpspec": "~2.1"

--- a/src/Spatie/Browsershot/Browsershot.php
+++ b/src/Spatie/Browsershot/Browsershot.php
@@ -73,6 +73,10 @@ class Browsershot
             $binFile = 'phantomjs.exe';
         }
 
+        if (defined('PHP_OS') && PHP_OS == 'Darwin') {
+            $binFile = 'phantomjs_macosx';
+        }
+
         return realpath(dirname(__FILE__).'/../../../bin/'.$binFile);
     }
 


### PR DESCRIPTION
This fixes `could not create screenshot` errors for MacOS users without using `setBinPath` and manually downloading phantomjs for Mac.