### PR TITLE
Add support for html input

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ It will save a pdf if the path passed to the `save` method has a `pdf` extension
 Browsershot::url('https://example.com')->save('example.pdf');
 ```
 
+You can also use arbitrary html input, simply replace the `url` method with `html`:
+
+```php
+Browsershot::html('<h1>Hello world!!</h1>')->save('example.pdf');
+```
+
 Spatie is a webdesign agency in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
 ## Postcardware

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It will save a pdf if the path passed to the `save` method has a `pdf` extension
 Browsershot::url('https://example.com')->save('example.pdf');
 ```
 
-You can also use arbitrary html input, simply replace the `url` method with `html`:
+You can also use an arbitrary html input, simply replace the `url` method with `html`:
 
 ```php
 Browsershot::html('<h1>Hello world!!</h1>')->save('example.pdf');

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -183,7 +183,7 @@ class Browsershot
 
     public function createScreenshotCommand(string $workingDirectory): string
     {
-        $url = $this->html ? $this->createTemporaryHtmlFile($this->html) : $this->url;
+        $url = $this->html ? $this->createTemporaryHtmlFile() : $this->url;
 
         $command = 'cd '
             .escapeshellarg($workingDirectory)
@@ -216,7 +216,7 @@ class Browsershot
 
     protected function createPdfCommand($targetPath): string
     {
-        $url = $this->html ? $this->createTemporaryHtmlFile($this->html) : $this->url;
+        $url = $this->html ? $this->createTemporaryHtmlFile() : $this->url;
 
         $command =
               escapeshellarg($this->findChrome())

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -13,6 +13,7 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 class Browsershot
 {
     protected $url = '';
+    protected $html = '';
 
     protected $pathToChrome = '';
     protected $timeout = 60;
@@ -23,19 +24,42 @@ class Browsershot
     protected $hideScrollbars = true;
     protected $userAgent = '';
 
+    protected $temporaryHtmlDirectory;
+
     /** @var \Spatie\Image\Manipulations */
     protected $imageManipulations;
 
     public static function url(string $url)
     {
-        return new static($url);
+        return (new static)->setUrl($url);
     }
 
-    public function __construct(string $url)
+    public static function html(string $html)
+    {
+        return (new static)->setHtml($html);
+    }
+
+    public function __construct(string $url = '')
     {
         $this->url = $url;
 
         $this->imageManipulations = new Manipulations();
+    }
+
+    public function setUrl(string $url)
+    {
+        $this->url = $url;
+        $this->html = '';
+
+        return $this;
+    }
+
+    public function setHtml(string $html)
+    {
+        $this->html = $html;
+        $this->url = '';
+
+        return $this;
     }
 
     public function setChromePath(string $pathToChrome)
@@ -117,6 +141,8 @@ class Browsershot
 
             $process->run();
 
+            $this->cleanupTemporaryHtmlFile();
+
             if (! $process->isSuccessful()) {
                 throw new ProcessFailedException($process);
             }
@@ -144,6 +170,8 @@ class Browsershot
         $process = (new Process($command))->setTimeout($this->timeout);
 
         $process->run();
+
+        $this->cleanupTemporaryHtmlFile();
     }
 
     public function applyManipulations(string $imagePath)
@@ -155,12 +183,14 @@ class Browsershot
 
     public function createScreenshotCommand(string $workingDirectory): string
     {
+        $url = $this->html ? $this->createTemporaryHtmlFile($this->html) : $this->url;
+
         $command = 'cd '
             .escapeshellarg($workingDirectory)
             .';'
             .escapeshellarg($this->findChrome())
             .' --headless --screenshot '
-            .escapeshellarg($this->url);
+            .escapeshellarg($url);
 
         if ($this->disableGpu) {
             $command .= ' --disable-gpu';
@@ -186,6 +216,8 @@ class Browsershot
 
     protected function createPdfCommand($targetPath): string
     {
+        $url = $this->html ? $this->createTemporaryHtmlFile($this->html) : $this->url;
+
         $command =
               escapeshellarg($this->findChrome())
             ." --headless --print-to-pdf={$targetPath}";
@@ -202,9 +234,25 @@ class Browsershot
             $command .= ' --user-agent='.escapeshellarg($this->userAgent);
         }
 
-        $command .= ' '.escapeshellarg($this->url);
+        $command .= ' '.escapeshellarg($url);
 
         return $command;
+    }
+
+    protected function createTemporaryHtmlFile(): string
+    {
+        $this->temporaryHtmlDirectory = (new TemporaryDirectory())->create();
+
+        file_put_contents($temporaryHtmlFile = $this->temporaryHtmlDirectory->path('index.html'), $this->html);
+
+        return "file://{$temporaryHtmlFile}";
+    }
+
+    protected function cleanupTemporaryHtmlFile()
+    {
+        if ($this->temporaryHtmlDirectory) {
+            $this->temporaryHtmlDirectory->delete();
+        }
     }
 
     protected function findChrome(): string

--- a/src/ChromeFinder.php
+++ b/src/ChromeFinder.php
@@ -9,6 +9,7 @@ class ChromeFinder
     protected $paths = [
         'Darwin' => [
             '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+            '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
         ],
         'Linux' => [
             '/usr/bin/google-chrome',

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -24,6 +24,17 @@ class BrowsershotTest extends TestCase
     }
 
     /** @test */
+    public function it_can_take_a_screenshot_of_arbitrary_html()
+    {
+        $targetPath = __DIR__.'/temp/testScreenshot.png';
+
+        $this->configureForCurrentEnvironment(Browsershot::html('<h1>Hello world!!</h1>'))
+            ->save($targetPath);
+
+        $this->assertFileExists($targetPath);
+    }
+
+    /** @test */
     public function it_can_save_a_pdf_by_using_the_pdf_extension()
     {
         $targetPath = __DIR__.'/temp/testPdf.pdf';
@@ -97,8 +108,11 @@ class BrowsershotTest extends TestCase
 
     protected function getBrowsershotForCurrentEnvironment(): Browsershot
     {
-        $browsershot = Browsershot::url('https://example.com');
+        return $this->configureForCurrentEnvironment(Browsershot::url('https://example.com'));
+    }
 
+    protected function configureForCurrentEnvironment(Browsershot $browsershot): Browsershot
+    {
         if (getenv('TRAVIS')) {
             $browsershot->setChromePath('google-chrome-stable');
         }

--- a/tests/ChromeFinderTest.php
+++ b/tests/ChromeFinderTest.php
@@ -12,7 +12,7 @@ class ChromeFinderTest extends TestCase
     {
         $this->skipIfNotRunningonMacOS();
 
-        $this->assertStringEndsWith('Chrome', ChromeFinder::forCurrentOperatingSystem());
+        $this->assertContains('Chrome', ChromeFinder::forCurrentOperatingSystem());
     }
 
     /** @test */


### PR DESCRIPTION
Hey, this PR adds support for rendering arbitrary html input using a new `html` method:

```php
Browsershot::html('<h1>Hello world!!</h1>);
```

This is achieved by creating a temporary html file using the `TemporaryDirectory` component already used in the library, which is then passed to Chrome via `file://` scheme and cleaned up once we have the result.

Use case - a lot of rendered pdfs in web apps like invoices contain private information which makes it awkward to use with Browsershot, since you can't expose this data on a public url. An alternative is to use a temporary file, which can be easily done in a code wrapping Browsershot, but I think it's such a common case it would be nice to have this directly in Browsershot. This makes rendering an invoice as simple as:

```php
$pdf = Browsershot::html(view('invoice')->with(compact('order'))->render())
     ->export('invoice.pdf');
```

I've also added Chrome Canary path for MacOS and updated the test to pass with Canary.

Thanks for considering this feature!