### PR TITLE
Add the default path for linux Chromium users

### DIFF
--- a/src/ChromeFinder.php
+++ b/src/ChromeFinder.php
@@ -12,6 +12,7 @@ class ChromeFinder
             '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
         ],
         'Linux' => [
+            '/usr/bin/chromium',
             '/usr/bin/google-chrome',
         ],
     ];


### PR DESCRIPTION
For instance, Debian users are most likely to have Chromium than Google Chrome on their system.