### PR TITLE
Puppeteer rework - improved error handling & installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ On a [Forge](https://forge.laravel.com) provisioned Ubuntu 16.04 server you can 
 
 ```bash
 curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-sudo apt-get install -y nodejs
-sudo npm install --global puppeteer
+sudo apt-get install -y nodejs gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+sudo npm install --global --unsafe-perm puppeteer
+sudo chmod -R o+rx /usr/lib/node_modules/puppeteer/.local-chromium
 ```
 
 ## Installation

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -5,20 +5,31 @@ const puppeteer = require('puppeteer')
 const request = JSON.parse(process.argv[2])
 
 let fn = (async () => {
-    const browser = await puppeteer.launch()
-    const page = await browser.newPage()
+    let browser, page
 
-    if (request.options && request.options.userAgent) {
-        await page.setUserAgent(request.options.userAgent)
+    try {
+        browser = await puppeteer.launch()
+        page = await browser.newPage()
+
+        if (request.options && request.options.userAgent) {
+            await page.setUserAgent(request.options.userAgent)
+        }
+
+        if (request.options && request.options.viewport) {
+            await page.setViewport(request.options.viewport)
+        }
+
+        await page.goto(request.url)
+
+        console.log(await page[request.action](request.options))
+
+        await browser.close()
+    } catch (e) {
+        if (browser) {
+            await browser.close()
+        }
+
+        console.error(e)
+        process.exit(1)
     }
-
-    if (request.options && request.options.viewport) {
-        await page.setViewport(request.options.viewport)
-    }
-
-    await page.goto(request.url)
-
-    console.log(await page[request.action](request.options))
-
-    await browser.close()
 })()

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -182,7 +182,7 @@ class Browsershot
         $this->cleanupTemporaryHtmlFile();
 
         if (! file_exists($targetPath)) {
-            throw CouldNotTakeBrowsershot::chromeOutputEmpty($targetPath, $process);
+            throw CouldNotTakeBrowsershot::chromeOutputEmpty($targetPath);
         }
 
         if (! $this->imageManipulations->isEmpty()) {
@@ -206,7 +206,7 @@ class Browsershot
         $this->cleanupTemporaryHtmlFile();
 
         if (! file_exists($targetPath)) {
-            throw CouldNotTakeBrowsershot::chromeOutputEmpty($targetPath, $process);
+            throw CouldNotTakeBrowsershot::chromeOutputEmpty($targetPath);
         }
     }
 

--- a/src/Exceptions/CouldNotTakeBrowsershot.php
+++ b/src/Exceptions/CouldNotTakeBrowsershot.php
@@ -3,35 +3,11 @@
 namespace Spatie\Browsershot\Exceptions;
 
 use Exception;
-use Symfony\Component\Process\Process;
 
 class CouldNotTakeBrowsershot extends Exception
 {
-    public static function operatingSystemNotSupported(string $operatingSystem)
+    public static function chromeOutputEmpty(string $screenShotPath)
     {
-        return new static("The current operating system `{$operatingSystem}` is not supported");
-    }
-
-    /**
-     * @param array|string $locations
-     *
-     * @return static
-     */
-    public static function chromeNotFound($locations)
-    {
-        if (! is_array($locations)) {
-            $locations = [$locations];
-        }
-
-        $locations = implode(', ', $locations);
-
-        return new static("Did not find Chrome at: {$locations}");
-    }
-
-    public static function chromeOutputEmpty(string $screenShotPath, Process $process)
-    {
-        $errorOutput = $process->getErrorOutput();
-
-        return new static("For some reason Chrome did not write a file at `{$screenShotPath}`. Error output: `{$errorOutput}`");
+        return new static("For some reason Chrome did not write a file at `{$screenShotPath}`.");
     }
 }

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Browsershot\Test;
 
 use Spatie\Browsershot\Browsershot;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 
 class BrowsershotTest extends TestCase
 {
@@ -109,6 +110,17 @@ class BrowsershotTest extends TestCase
         $this->assertFileExists($targetPath);
 
         $this->assertEquals('application/pdf', mime_content_type($targetPath));
+    }
+
+    /** @test */
+    public function it_can_handle_a_permissions_error()
+    {
+        $targetPath = '/cantWriteThisPdf.png';
+
+        $this->expectException(ProcessFailedException::class);
+
+        Browsershot::url('https://example.com')
+            ->save($targetPath);
     }
 
     /** @test */


### PR DESCRIPTION
Follow-up PR for https://github.com/spatie/browsershot/pull/85

- improved error handling when calling the browser
  - now correctly returns error instead of waiting for timeout on error
- fixed undefined variable usage & removed unused error handling code
  - I don't think we need the `CouldNotTakeBrowsershot` exception at all since Puppeteer should return error if it can't write the screenshot/pdf, but I left it in just to be sure
- updated installation instructions
  - based on clean Ubuntu 16.04 installation

We might consider installing Chrome via apt like before, so we can keep it easily updated and avoid installing all these dependencies explicitly - I can PR that later.
