### PR TITLE
Page formats

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -27,6 +27,7 @@ class Browsershot
     protected $pages = '';
     protected $paperWidth = 0;
     protected $paperHeight = 0;
+    protected $format = null;
     protected $userAgent = '';
     protected $windowWidth = 800;
     protected $windowHeight = 600;
@@ -136,6 +137,14 @@ class Browsershot
     {
         $this->paperWidth = $width;
         $this->paperHeight = $height;
+
+        return $this;
+    }
+
+    // paper format
+    public function format(string $format)
+    {
+        $this->format = $format;
 
         return $this;
     }
@@ -275,6 +284,10 @@ class Browsershot
         if ($this->paperWidth > 0 && $this->paperHeight > 0) {
             $command['options']['width'] = $this->paperWidth.'mm';
             $command['options']['height'] = $this->paperHeight.'mm';
+        }
+
+        if ($this->format) {
+            $command['options']['format'] = $this->format;
         }
 
         return $command;

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -195,6 +195,36 @@ class BrowsershotTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_a_command_to_generate_a_pdf_with_paper_format()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->includeBackground()
+            ->landscape()
+            ->margins(10, 20, 30, 40)
+            ->pages('1-3')
+            ->format('a4')
+            ->createPdfCommand('screenshot.pdf');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'pdf',
+            'options' => [
+                'path' => 'screenshot.pdf',
+                'displayHeaderFooter' => true,
+                'printBackground' => true,
+                'landscape' => true,
+                'margins' => ['top' => '10mm', 'right' => '20mm', 'bottom' => '30mm', 'left' => '40mm'],
+                'pageRanges' => '1-3',
+                'format' => 'a4',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+            ],
+        ], $command);
+    }
+
+    /** @test */
     public function it_can_use_given_user_agent()
     {
         $command = Browsershot::url('https://example.com')


### PR DESCRIPTION
Puppeteer has a really handy features that allows you to specify paper format instead of sizes.

This makes for more readable and understandable code:
```php
// Paper size
Browsershot::url('https://example.com')->paperSize(297, 210)->save($targetPath);

// Paper format
Browsershot::url('https://example.com')->format('A4')->save($targetPath);
```

Available formats are listed here: https://github.com/GoogleChrome/puppeteer/blob/master/lib/Page.js#L780

We can also implement a "enum" class to list available formats instead of manually typing a string. 
Something as easy as:
```php
class PaperFormats
{
    const LETTER = 'letter';
    const LEGAL = 'legal';
    const TABLOID = 'tabloid';
    const LEDGER = 'ledger';
    const A0 = 'a0';
    const A1 = 'a1';
    const A2 = 'a2';
    const A3 = 'a3';
    const A4 = 'a4';
    const A5 = 'a5';
}

// Usage
Browsershot::url('https://example.com')->format(PaperFormats::A4)->save($targetPath);
```
This would make the class implementation-agnostic and user won't have to lookup puppeteer source code to find out if its format is available.

I can add a commit with this as well.
