### PR TITLE
Improved compatibility with macOS?

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -340,7 +340,7 @@ class Browsershot
     {
         $binPath = __DIR__.'/../bin/browser.js';
 
-        $cli = 'NODE_PATH=`npm root -g` '
+        $cli = 'PATH=$PATH:/usr/local/bin NODE_PATH=`npm root -g` '
             .escapeshellarg($binPath).' '
             .escapeshellarg(json_encode($command));
 


### PR DESCRIPTION
Hey, so I'm trying to use this in a real project for the first time and I've run into some issues.

In my local dev environment using latest macOS and Laravel Valet the node call ends with a command not found error. Now obviously this is some PATH issue, as the same code works completely fine deployed on an Ubuntu server.

After a bit of trial and error I got it to work simply by prefixing the call with `PATH=$PATH`. Honestly, no idea why this works. 🤷‍♂️

I've also appended `/usr/bin/local` to the PATH, which is not really necessary in my case, but will help if the system-wide PATH does not contain that path for some reason.


