### PR TITLE
Configureable node binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,17 +65,18 @@ sudo npm install --global --unsafe-perm puppeteer
 sudo chmod -R o+rx /usr/lib/node_modules/puppeteer/.local-chromium
 ```
 
-### Custom node binary path
+### Custom node and npm binaries
 
-Depending on your setup, node might be not directly available to Browsershot. 
-If you need to manually set the node binary path, you can do this by calling the `setNodeBinary` method.
+Depending on your setup, node or npm might be not directly available to Browsershot. 
+If you need to manually set these binary paths, you can do this by calling the `setNodeBinary` and `setNpmBinary` method.
 
 ```
 Browsershot::html('Foo')
-    ->setNodeBinary('/usr/local/bin/node');
+    ->setNodeBinary('/usr/local/bin/node')
+    ->setNodeBinary('/usr/local/bin/npm');
 ``` 
 
-By default, Browsershot will use `node` to execute commands.
+By default, Browsershot will use `node` and `npm` to execute commands.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ sudo npm install --global --unsafe-perm puppeteer
 sudo chmod -R o+rx /usr/lib/node_modules/puppeteer/.local-chromium
 ```
 
+### Custom node binary path
+
+Depending on your setup, node might be not directly available to Browsershot. 
+If you need to manually set the node binary path, you can do this by calling the `setNodeBinary` method.
+
+```
+Browsershot::html('Foo')
+    ->setNodeBinary('/usr/local/bin/node');
+``` 
+
+By default, Browsershot will use `node` to execute commands.
+
 ## Installation
 
 This package can be installed through Composer.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ Browsershot::html('Foo')
 
 By default, Browsershot will use `node` and `npm` to execute commands.
 
+### Custom include path
+
+If you don't want to manually specify binary paths, but rather modify the include path in general,
+you can set it using the `setIncludePath` method.
+
+```php
+Browsershot::html('Foo')
+    ->setIncludePath('$PATH:/usr/local/bin')
+```
+
+Setting the include path can be useful in cases where `node` and `npm` can not be found automatically.
+
 ## Installation
 
 This package can be installed through Composer.

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 const puppeteer = require('puppeteer')
 
 const request = JSON.parse(process.argv[2])

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -13,6 +13,7 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 class Browsershot
 {
     protected $nodeBinary = 'node';
+    protected $npmBinary = 'npm';
     protected $clip = null;
     protected $deviceScaleFactor = 1;
     protected $format = null;
@@ -55,6 +56,13 @@ class Browsershot
     public function setNodeBinary(string $nodeBinary)
     {
         $this->nodeBinary = $nodeBinary;
+
+        return $this;
+    }
+
+    public function setNpmBinary(string $npmBinary)
+    {
+        $this->npmBinary = $npmBinary;
 
         return $this;
     }
@@ -347,8 +355,9 @@ class Browsershot
     protected function callBrowser(array $command)
     {
         $binPath = __DIR__.'/../bin/browser.js';
+        $setNodePathCommand = "NODE_PATH=`{$this->nodeBinary} {$this->npmBinary} root -g`";
 
-        $cli = 'NODE_PATH=`npm root -g` '
+        $cli = $setNodePathCommand.' '
             .$this->nodeBinary.' '
             .escapeshellarg($binPath).' '
             .escapeshellarg(json_encode($command));

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -14,6 +14,7 @@ class Browsershot
 {
     protected $nodeBinary = 'node';
     protected $npmBinary = 'npm';
+    protected $includePath = '$PATH:/usr/local/bin';
     protected $clip = null;
     protected $deviceScaleFactor = 1;
     protected $format = null;
@@ -63,6 +64,13 @@ class Browsershot
     public function setNpmBinary(string $npmBinary)
     {
         $this->npmBinary = $npmBinary;
+
+        return $this;
+    }
+
+    public function setIncludePath(string $includePath)
+    {
+        $this->includePath = $includePath;
 
         return $this;
     }
@@ -354,10 +362,13 @@ class Browsershot
 
     protected function callBrowser(array $command)
     {
-        $binPath = __DIR__.'/../bin/browser.js';
+        $setIncludePathCommand = "PATH={$this->includePath}";
         $setNodePathCommand = "NODE_PATH=`{$this->nodeBinary} {$this->npmBinary} root -g`";
+        $binPath = __DIR__.'/../bin/browser.js';
 
-        $cli = $setNodePathCommand.' '
+        $cli =
+            $setIncludePathCommand.' '
+            .$setNodePathCommand.' '
             .$this->nodeBinary.' '
             .escapeshellarg($binPath).' '
             .escapeshellarg(json_encode($command));

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -12,6 +12,7 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 /** @mixin \Spatie\Image\Manipulations */
 class Browsershot
 {
+    protected $nodeBinary = 'node';
     protected $clip = null;
     protected $deviceScaleFactor = 1;
     protected $format = null;
@@ -49,6 +50,13 @@ class Browsershot
         $this->url = $url;
 
         $this->imageManipulations = new Manipulations();
+    }
+
+    public function setNodeBinary(string $nodeBinary)
+    {
+        $this->nodeBinary = $nodeBinary;
+
+        return $this;
     }
 
     public function setUrl(string $url)
@@ -341,6 +349,7 @@ class Browsershot
         $binPath = __DIR__.'/../bin/browser.js';
 
         $cli = 'NODE_PATH=`npm root -g` '
+            .$this->nodeBinary.' '
             .escapeshellarg($binPath).' '
             .escapeshellarg(json_encode($command));
 

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -254,4 +254,16 @@ class BrowsershotTest extends TestCase
             ->setNodeBinary('non-existant/bin/wich/causes/an/exception')
             ->save($targetPath);
     }
+
+    /** @test */
+    public function it_can_set_the_include_path_and_still_works()
+    {
+        $targetPath = __DIR__.'/temp/testScreenshot.png';
+
+        Browsershot::html('Foo')
+            ->setIncludePath('$PATH:/usr/local/bin:/mypath')
+            ->save($targetPath);
+
+        $this->assertFileExists($targetPath);
+    }
 }

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -242,4 +242,16 @@ class BrowsershotTest extends TestCase
             ],
         ], $command);
     }
+
+    /** @test */
+    public function it_can_set_another_node_binary()
+    {
+        $this->expectException(ProcessFailedException::class);
+
+        $targetPath = __DIR__.'/temp/testScreenshot.png';
+
+        Browsershot::html('Foo')
+            ->setNodeBinary('non-existant/bin/wich/causes/an/exception')
+            ->save($targetPath);
+    }
 }


### PR DESCRIPTION
This pull requests adds the possibility to configure the node binary manually by calling the  `setNodeBinary` method.

Furthermore, the default environment in `browser.js` is removed. This fixed environment caused an error to occur when rendering a PDF within a web request. My best guess as to why this happens is because nginx doesn't use the same include paths as the terminal. The result was that PDFs could not be rendered on the fly in a Mac/nginx setup, because `node` was not a known environment.

By making the node binary configurable, this problem can be solved regardless of which system is running the library. A path to the node binary can be specified, and will default to `node`. 