### PR TITLE
Add network idle timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,16 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
+#### Set a network idle timeout
+
+You can tell Browsershot to wait x-amount of milliseconds before saving the HTML page.
+This feature can be useful when you're using asynchronous fonts or images, and they require a bit more time to load.
+
+```php
+Browsershot::url('https://example.com')
+    ->setNetworkIdleTimeout(1000);
+```
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -19,7 +19,14 @@ const callChrome = async () => {
             await page.setViewport(request.options.viewport);
         }
 
-        await page.goto(request.url);
+        let requestOptions = {};
+
+        if (request.options && request.options.networkIdleTimeout) {
+            requestOptions.waitUntil = 'networkidle';
+            requestOptions.networkIdleTimeout = request.options.networkIdleTimeout;
+        }
+
+        await page.goto(request.url, requestOptions);
 
         console.log(await page[request.action](request.options));
 

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -19,7 +19,7 @@ const callChrome = async () => {
             await page.setViewport(request.options.viewport);
         }
 
-        let requestOptions = {};
+        const requestOptions = {};
 
         if (request.options && request.options.networkIdleTimeout) {
             requestOptions.waitUntil = 'networkidle';

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -15,6 +15,7 @@ class Browsershot
     protected $nodeBinary = 'node';
     protected $npmBinary = 'npm';
     protected $includePath = '$PATH:/usr/local/bin';
+    protected $networkIdleTimeout = 0;
     protected $clip = null;
     protected $deviceScaleFactor = 1;
     protected $format = null;
@@ -71,6 +72,13 @@ class Browsershot
     public function setIncludePath(string $includePath)
     {
         $this->includePath = $includePath;
+
+        return $this;
+    }
+
+    public function setNetworkIdleTimeout(int $networkIdleTimeout)
+    {
+        $this->networkIdleTimeout = $networkIdleTimeout;
 
         return $this;
     }
@@ -339,6 +347,10 @@ class Browsershot
 
         if ($this->deviceScaleFactor > 1) {
             $command['options']['viewport']['deviceScaleFactor'] = $this->deviceScaleFactor;
+        }
+
+        if ($this->networkIdleTimeout > 0) {
+            $command['options']['networkIdleTimeout'] = $this->networkIdleTimeout;
         }
 
         return $command;

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -266,4 +266,16 @@ class BrowsershotTest extends TestCase
 
         $this->assertFileExists($targetPath);
     }
+
+    /** @test */
+    public function it_can_take_a_request_idle_timeout()
+    {
+        $targetPath = __DIR__.'/temp/testScreenshot.png';
+
+        Browsershot::html('Foo')
+            ->setNetworkIdleTimeout(100)
+            ->save($targetPath);
+
+        $this->assertFileExists($targetPath);
+    }
 }


### PR DESCRIPTION
This PR adds a configurable option to Browsershot with which you can set a network idle timeout. This parameter is passed directly to Puppeteer, and used to wait x-amount of request idle time before saving the page. This can be useful to wait for asynchronous fonts or images to load.

```
Browsershot::html('Foo')
    ->setNetworkIdleTimeout(100)
    ->save($targetPath);
```