### PR TITLE
Default npm path bugfix

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -12,8 +12,8 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 /** @mixin \Spatie\Image\Manipulations */
 class Browsershot
 {
-    protected $nodeBinary = 'node';
-    protected $npmBinary = 'npm';
+    protected $nodeBinary = null;
+    protected $npmBinary = null;
     protected $includePath = '$PATH:/usr/local/bin';
     protected $networkIdleTimeout = 0;
     protected $clip = null;
@@ -388,14 +388,20 @@ class Browsershot
     {
         $setIncludePathCommand = "PATH={$this->includePath}";
 
-        $setNodePathCommand = "NODE_PATH=`{$this->nodeBinary} {$this->npmBinary} root -g`";
+        $nodeBinary = $this->nodeBinary ?: 'node';
+
+        if ($this->npmBinary) {
+            $setNodePathCommand = "NODE_PATH=`{$nodeBinary} {$this->npmBinary} root -g`";
+        } else {
+            $setNodePathCommand = "NODE_PATH=`npm root -g`";
+        }
 
         $binPath = __DIR__.'/../bin/browser.js';
 
         $fullCommand =
             $setIncludePathCommand.' '
             .$setNodePathCommand.' '
-            .$this->nodeBinary.' '
+            .$nodeBinary.' '
             .escapeshellarg($binPath).' '
             .escapeshellarg(json_encode($command));
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -393,7 +393,7 @@ class Browsershot
         if ($this->npmBinary) {
             $setNodePathCommand = "NODE_PATH=`{$nodeBinary} {$this->npmBinary} root -g`";
         } else {
-            $setNodePathCommand = "NODE_PATH=`npm root -g`";
+            $setNodePathCommand = 'NODE_PATH=`npm root -g`';
         }
 
         $binPath = __DIR__.'/../bin/browser.js';

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -390,11 +390,7 @@ class Browsershot
 
         $nodeBinary = $this->nodeBinary ?: 'node';
 
-        if ($this->npmBinary) {
-            $setNodePathCommand = "NODE_PATH=`{$nodeBinary} {$this->npmBinary} root -g`";
-        } else {
-            $setNodePathCommand = 'NODE_PATH=`npm root -g`';
-        }
+        $setNodePathCommand = $this->getNodePathCommand($nodeBinary);
 
         $binPath = __DIR__.'/../bin/browser.js';
 
@@ -414,5 +410,14 @@ class Browsershot
         }
 
         return $process->getOutput();
+    }
+
+    protected function getNodePathCommand(string $nodeBinary): string
+    {
+        if ($this->npmBinary) {
+            return "NODE_PATH=`{$nodeBinary} {$this->npmBinary} root -g`";
+        }
+
+        return 'NODE_PATH=`npm root -g`';
     }
 }


### PR DESCRIPTION
This PR changes the way the `NODE_PATH` is set, so that npm can be run when no specific binary is supplied.

Only when a specific npm binary is supplied will the `NODE_PATH` be set using the custom paths. Otherwise, npm will be executed like normal.