### PR TITLE
ignoreHTTPSErrors by default

### DIFF
--- a/bin/browser.js
+++ b/bin/browser.js
@@ -7,7 +7,10 @@ const callChrome = async () => {
     let page;
 
     try {
-        browser = await puppeteer.launch({ args: request.options.args || [] });
+        browser = await puppeteer.launch({
+            ignoreHTTPSErrors: true,
+            args: request.options.args || []
+        });
 
         page = await browser.newPage();
 


### PR DESCRIPTION
This adds `ignoreHTTPSErrors: true` to the package by default in order to prevent https errors when adding non-https elements to a render.