### PR TITLE
option to ignore HTTPs errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ sudo chmod -R o+rx /usr/lib/node_modules/puppeteer/.local-chromium
 
 ### Custom node and npm binaries
 
-Depending on your setup, node or npm might be not directly available to Browsershot. 
+Depending on your setup, node or npm might be not directly available to Browsershot.
 If you need to manually set these binary paths, you can do this by calling the `setNodeBinary` and `setNpmBinary` method.
 
 ```
 Browsershot::html('Foo')
     ->setNodeBinary('/usr/local/bin/node')
     ->setNpmBinary('/usr/local/bin/npm');
-``` 
+```
 
 By default, Browsershot will use `node` and `npm` to execute commands.
 
@@ -301,6 +301,16 @@ Browsershot::url('https://example.com')
    ...
 ```
 
+#### Ignore HTTPS errors
+
+You can ignore HTTPS errors, if necessary.
+
+```php
+Browsershot::url('https://example.com')
+   ->ignoreHttpsErrors()
+   ...
+```
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
@@ -332,7 +342,7 @@ All postcards are published [on our website](https://spatie.be/en/opensource/pos
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
-Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie). 
+Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie).
 All pledges will be dedicated to allocating workforce on maintenance and new awesome stuff.
 
 ## License

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -7,7 +7,10 @@ const callChrome = async () => {
     let page;
 
     try {
-        browser = await puppeteer.launch({ args: request.options.args || [] });
+        browser = await puppeteer.launch({
+            ignoreHTTPSErrors: request.options.ignoreHttpsErrors,
+            args: request.options.args || []
+        });
 
         page = await browser.newPage();
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -21,6 +21,7 @@ class Browsershot
     protected $format = null;
     protected $fullPage = false;
     protected $html = '';
+    protected $ignoreHttpsErrors = false;
     protected $landscape = false;
     protected $margins = null;
     protected $noSandbox = false;
@@ -148,6 +149,13 @@ class Browsershot
     public function hideBackground()
     {
         $this->showBackground = false;
+
+        return $this;
+    }
+
+    public function ignoreHttpsErrors()
+    {
+        $this->ignoreHttpsErrors = true;
 
         return $this;
     }
@@ -359,6 +367,10 @@ class Browsershot
 
         if ($this->networkIdleTimeout > 0) {
             $command['options']['networkIdleTimeout'] = $this->networkIdleTimeout;
+        }
+
+        if ($this->ignoreHttpsErrors) {
+            $command['options']['ignoreHttpsErrors'] = $this->ignoreHttpsErrors;
         }
 
         if ($this->noSandbox) {

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -301,4 +301,25 @@ class BrowsershotTest extends TestCase
             ],
         ], $command);
     }
+
+    /** @test */
+    public function it_can_ignore_https_errors()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->ignoreHttpsErrors()
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'ignoreHttpsErrors' => true,
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+            ],
+        ], $command);
+    }
 }


### PR DESCRIPTION
Here's another attempt at fixing HTTPS errors that may pop up.
Now you can pass an optional `->ignoreHttpsErrors()`
By default, HTTPS errors are not ignored.

I'm pretty new to this, so I'll add some comments to the PR so you can follow my thought process. Again, no hard feelings if this isn't what you're looking for. I really appreciate the opportunity to contribute, and I'm thankful for all your hard work. I'm open to any and all feedback / suggestions / etc.

Thank you!