### PR TITLE
Allow the use of the 'omitBackground' option when capturing screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ Browsershot::url('https://example.com')
 #### Mobile emulation
 
 You can emulate a mobile view with the `mobile` and `touch` methods.
-`mobile` will set the display to take into account the page's meta viewport, as Chrome mobile would. 
-`touch` will set the browser to emulate touch functionality, hence allowing spoofing for pages that check for touch. 
+`mobile` will set the display to take into account the page's meta viewport, as Chrome mobile would.
+`touch` will set the browser to emulate touch functionality, hence allowing spoofing for pages that check for touch.
 Along with the `userAgent` method, these can be used to effectively take a mobile screenshot of the page.
 
 ```php
@@ -188,12 +188,11 @@ Browsershot::url('https://example.com')
 ```
 
 #### Backgrounds
-The screenshot command will ignore the website background by default. If you want to capture the
-background as part of your screenshot use the `showBackground` option.
+If you want to ignore the website's background when capturing a screenshot, use the `hideBackground()` method.
 
 ```php
 Browsershot::url('https://example.com')
-    ->showBackground()
+    ->hideBackground()
     ->save($pathToImage);
 ```
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,15 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
+#### Backgrounds
+The screenshot command will ignore the website background by default. If you want to capture the
+background as part of your screenshot use the `showBackground` option.
+
+```php
+Browsershot::url('https://example.com')
+    ->showBackground()
+    ->save($pathToImage);
+```
 
 ### PDFs
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -29,6 +29,7 @@ class Browsershot
     protected $paperHeight = 0;
     protected $paperWidth = 0;
     protected $showBackground = false;
+    protected $omitScreenshotBackground = false;
     protected $showBrowserHeaderAndFooter = false;
     protected $temporaryHtmlDirectory;
     protected $timeout = 60;
@@ -144,6 +145,7 @@ class Browsershot
     public function showBackground()
     {
         $this->showBackground = true;
+        $this->omitScreenshotBackground = false;
 
         return $this;
     }
@@ -151,6 +153,7 @@ class Browsershot
     public function hideBackground()
     {
         $this->showBackground = false;
+        $this->omitScreenshotBackground = true;
 
         return $this;
     }
@@ -318,7 +321,7 @@ class Browsershot
             $command['options']['clip'] = $this->clip;
         }
 
-        if (! $this->showBackground) {
+        if ($this->omitScreenshotBackground) {
             $command['options']['omitBackground'] = true;
         }
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -318,6 +318,10 @@ class Browsershot
             $command['options']['clip'] = $this->clip;
         }
 
+        if (! $this->showBackground) {
+            $command['options']['omitBackground'] = true;
+        }
+
         return $command;
     }
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -29,7 +29,7 @@ class Browsershot
     protected $paperHeight = 0;
     protected $paperWidth = 0;
     protected $showBackground = false;
-    protected $omitScreenshotBackground = false;
+    protected $showScreenshotBackground = true;
     protected $showBrowserHeaderAndFooter = false;
     protected $temporaryHtmlDirectory;
     protected $timeout = 60;
@@ -145,7 +145,7 @@ class Browsershot
     public function showBackground()
     {
         $this->showBackground = true;
-        $this->omitScreenshotBackground = false;
+        $this->showScreenshotBackground = true;
 
         return $this;
     }
@@ -153,7 +153,7 @@ class Browsershot
     public function hideBackground()
     {
         $this->showBackground = false;
-        $this->omitScreenshotBackground = true;
+        $this->showScreenshotBackground = false;
 
         return $this;
     }
@@ -321,7 +321,7 @@ class Browsershot
             $command['options']['clip'] = $this->clip;
         }
 
-        if ($this->omitScreenshotBackground) {
+        if (! $this->showScreenshotBackground) {
             $command['options']['omitBackground'] = true;
         }
 

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -156,6 +156,32 @@ class BrowsershotTest extends TestCase
                 'clip' => ['x' => 100, 'y' => 50, 'width' => 600, 'height' => 400],
                 'path' => 'screenshot.png',
                 'fullPage' => true,
+                'omitBackground' => true,
+                'viewport' => [
+                    'deviceScaleFactor' => 2,
+                    'width' => 1920,
+                    'height' => 1080,
+                ],
+            ],
+        ], $command);
+    }
+
+    /** @test */
+    public function it_can_create_a_command_to_generate_a_screenshot_and_keep_the_background()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->clip(100, 50, 600, 400)
+            ->deviceScaleFactor(2)
+            ->showBackground()
+            ->windowSize(1920, 1080)
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'clip' => ['x' => 100, 'y' => 50, 'width' => 600, 'height' => 400],
+                'path' => 'screenshot.png',
                 'viewport' => [
                     'deviceScaleFactor' => 2,
                     'width' => 1920,
@@ -236,6 +262,7 @@ class BrowsershotTest extends TestCase
             'action' => 'screenshot',
             'options' => [
                 'path' => 'screenshot.png',
+                'omitBackground' => true,
                 'viewport' => [
                     'width' => 800,
                     'height' => 600,
@@ -293,6 +320,7 @@ class BrowsershotTest extends TestCase
             'action' => 'screenshot',
             'options' => [
                 'path' => 'screenshot.png',
+                'omitBackground' => true,
                 'viewport' => [
                     'width' => 800,
                     'height' => 600,
@@ -317,6 +345,7 @@ class BrowsershotTest extends TestCase
             'options' => [
                 'ignoreHttpsErrors' => true,
                 'path' => 'screenshot.png',
+                'omitBackground' => true,
                 'viewport' => [
                     'width' => 800,
                     'height' => 600,

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -156,7 +156,6 @@ class BrowsershotTest extends TestCase
                 'clip' => ['x' => 100, 'y' => 50, 'width' => 600, 'height' => 400],
                 'path' => 'screenshot.png',
                 'fullPage' => true,
-                'omitBackground' => true,
                 'viewport' => [
                     'deviceScaleFactor' => 2,
                     'width' => 1920,
@@ -167,12 +166,12 @@ class BrowsershotTest extends TestCase
     }
 
     /** @test */
-    public function it_can_create_a_command_to_generate_a_screenshot_and_keep_the_background()
+    public function it_can_create_a_command_to_generate_a_screenshot_and_omit_the_background()
     {
         $command = Browsershot::url('https://example.com')
             ->clip(100, 50, 600, 400)
             ->deviceScaleFactor(2)
-            ->showBackground()
+            ->hideBackground()
             ->windowSize(1920, 1080)
             ->createScreenshotCommand('screenshot.png');
 
@@ -182,6 +181,7 @@ class BrowsershotTest extends TestCase
             'options' => [
                 'clip' => ['x' => 100, 'y' => 50, 'width' => 600, 'height' => 400],
                 'path' => 'screenshot.png',
+                'omitBackground' => true,
                 'viewport' => [
                     'deviceScaleFactor' => 2,
                     'width' => 1920,
@@ -262,7 +262,6 @@ class BrowsershotTest extends TestCase
             'action' => 'screenshot',
             'options' => [
                 'path' => 'screenshot.png',
-                'omitBackground' => true,
                 'viewport' => [
                     'width' => 800,
                     'height' => 600,
@@ -320,7 +319,6 @@ class BrowsershotTest extends TestCase
             'action' => 'screenshot',
             'options' => [
                 'path' => 'screenshot.png',
-                'omitBackground' => true,
                 'viewport' => [
                     'width' => 800,
                     'height' => 600,
@@ -345,7 +343,6 @@ class BrowsershotTest extends TestCase
             'options' => [
                 'ignoreHttpsErrors' => true,
                 'path' => 'screenshot.png',
-                'omitBackground' => true,
                 'viewport' => [
                     'width' => 800,
                     'height' => 600,


### PR DESCRIPTION
This PR uses the `showBackground` value in the Browsershot class to dictate whether or not Puppeteer's `omitBackground` option should be set when capturing screenshots. 

This could potentially be seen as a breaking change because the `showBackground` value defaults to false, which means that this flag might be set for users without them wanting it to be there. 

I will send a separate PR for the `setOption` idea. 

Thanks!
~Ryan