### PR TITLE
Dismiss dialogs feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,15 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
+#### Dismiss Dialogs
+Javascript dialog pop up such as alert, prompt, confirm cause rendering of the site to stop what leads to being unable to take a screenshot. `dismissDialogs()` method automatically close such popups allowing the  screenshot to be taken.
+
+```php
+Browsershot::url('https://example.com')
+    ->dismissDialogs()
+    ->save($pathToImage);
+```
+
 ### PDFs
 
 Browsershot will save a pdf if the path passed to the `save` method has a `pdf` extension.

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -14,6 +14,12 @@ const callChrome = async () => {
 
         page = await browser.newPage();
 
+        if (request.options && request.options.dismissDialogs) {
+            page.on('dialog', async dialog => {
+                await dialog.dismiss();
+            });
+        }
+
         if (request.options && request.options.userAgent) {
             await page.setUserAgent(request.options.userAgent);
         }

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -39,6 +39,7 @@ class Browsershot
     protected $windowWidth = 800;
     protected $mobile = false;
     protected $touch = false;
+    protected $dismissDialogs = false;
 
     /** @var \Spatie\Image\Manipulations */
     protected $imageManipulations;
@@ -210,6 +211,13 @@ class Browsershot
         return $this;
     }
 
+    public function dismissDialogs()
+    {
+    	$this->dismissDialogs = true;
+
+    	return $this;
+    }
+
     public function pages(string $pages)
     {
         $this->pages = $pages;
@@ -333,6 +341,10 @@ class Browsershot
 
         if (! $this->showScreenshotBackground) {
             $command['options']['omitBackground'] = true;
+        }
+
+        if($this->dismissDialogs) {
+	        $command['options']['dismissDialogs'] = true;
         }
 
         return $command;

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -75,6 +75,7 @@ class BrowsershotTest extends TestCase
         Browsershot::url('https://example.com')
             ->clip(290, 80, 700, 290)
             ->deviceScaleFactor(2)
+	        ->dismissDialogs()
             ->mobile()
             ->touch()
             ->windowSize(1280, 800)
@@ -146,6 +147,7 @@ class BrowsershotTest extends TestCase
             ->clip(100, 50, 600, 400)
             ->deviceScaleFactor(2)
             ->fullPage()
+	        ->dismissDialogs()
             ->windowSize(1920, 1080)
             ->createScreenshotCommand('screenshot.png');
 
@@ -156,6 +158,7 @@ class BrowsershotTest extends TestCase
                 'clip' => ['x' => 100, 'y' => 50, 'width' => 600, 'height' => 400],
                 'path' => 'screenshot.png',
                 'fullPage' => true,
+                'dismissDialogs' => true,
                 'viewport' => [
                     'deviceScaleFactor' => 2,
                     'width' => 1920,
@@ -329,6 +332,28 @@ class BrowsershotTest extends TestCase
             ],
         ], $command);
     }
+
+	/** @test */
+	public function it_can_dismiss_dialogs()
+	{
+		$command = Browsershot::url('https://example.com')
+		                      ->dismissDialogs()
+		                      ->createScreenshotCommand('screenshot.png');
+
+		$this->assertEquals([
+			'url' => 'https://example.com',
+			'action' => 'screenshot',
+			'options' => [
+				'dismissDialogs' => true,
+				'path' => 'screenshot.png',
+				'viewport' => [
+					'width' => 800,
+					'height' => 600,
+				],
+			],
+		], $command);
+	}
+
 
     /** @test */
     public function it_can_ignore_https_errors()


### PR DESCRIPTION
Javascript dialog pop up such as alert, prompt, confirm cause rendering of the site to stop what leads to being unable to take a screenshot. `dismissDialogs()` method automatically close such popups allowing the  screenshot to be taken.
