### PR TITLE
Move snapshot assertions to --dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     "require": {
         "php": "^7.0",
         "spatie/image": "~1.3.0",
-        "spatie/phpunit-snapshot-assertions": "^1.0",
         "spatie/temporary-directory": "^1.1",
         "symfony/process": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.1"
+        "phpunit/phpunit": "^6.1",
+        "spatie/phpunit-snapshot-assertions": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This isn't actually required, is it? 

Right now it's installed always, even on production, which doesn't seem to be needed, or am I overlooking something?