### PR TITLE
Add the ability to allow arbitrary options to be passed to puppeteer

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -481,7 +481,7 @@ class Browsershot
 
         $command['options']['args'] = $this->getOptionArgs();
 
-        if (!empty($this->additionalOptions)) {
+        if (! empty($this->additionalOptions)) {
             $command['options'] = array_merge($command['options'], $this->additionalOptions);
         }
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -41,6 +41,7 @@ class Browsershot
     protected $mobile = false;
     protected $touch = false;
     protected $dismissDialogs = false;
+    protected $additionalOptions = [];
 
     /** @var \Spatie\Image\Manipulations */
     protected $imageManipulations;
@@ -274,6 +275,32 @@ class Browsershot
         return $this;
     }
 
+    public function setOption($key, $value)
+    {
+        if (is_null($key)) {
+            return $this;
+        }
+
+        $keys = explode('.', $key);
+
+        $array = &$this->additionalOptions;
+
+        while (count($keys) > 1) {
+            $key = array_shift($keys);
+
+            if (! isset($array[$key]) || ! is_array($array[$key])) {
+                $array[$key] = [];
+            }
+
+            $array = &$array[$key];
+
+        }
+
+        $array[array_shift($keys)] = $value;
+
+        return $this;
+    }
+
     public function __call($name, $arguments)
     {
         $this->imageManipulations->$name(...$arguments);
@@ -454,6 +481,10 @@ class Browsershot
 
         $command['options']['args'] = $this->getOptionArgs();
 
+        if (!empty($this->additionalOptions)) {
+            $command['options'] = array_merge($command['options'], $this->additionalOptions);
+        }
+
         return $command;
     }
 
@@ -509,4 +540,5 @@ class Browsershot
 
         return 'NODE_PATH=`npm root -g`';
     }
+
 }

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -281,22 +281,16 @@ class Browsershot
             return $this;
         }
 
-        $keys = explode('.', $key);
+        $keys = array_reverse(explode('.', $key));
 
-        $array = &$this->additionalOptions;
-
-        while (count($keys) > 1) {
-            $key = array_shift($keys);
-
-            if (! isset($array[$key]) || ! is_array($array[$key])) {
-                $array[$key] = [];
+        $array = array_reduce($keys, function($carry, $item) use ($value) {
+            if (empty($carry)) {
+                $carry = $value;
             }
+            return [$item => $carry];
+        }, []);
 
-            $array = &$array[$key];
-
-        }
-
-        $array[array_shift($keys)] = $value;
+        $this->additionalOptions = array_merge_recursive($this->additionalOptions, $array);
 
         return $this;
     }
@@ -480,10 +474,6 @@ class Browsershot
         }
 
         $command['options']['args'] = $this->getOptionArgs();
-
-        if (! empty($this->additionalOptions)) {
-            $command['options'] = array_merge($command['options'], $this->additionalOptions);
-        }
 
         if (! empty($this->additionalOptions)) {
             $command['options'] = array_merge($command['options'], $this->additionalOptions);

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -283,10 +283,11 @@ class Browsershot
 
         $keys = array_reverse(explode('.', $key));
 
-        $array = array_reduce($keys, function($carry, $item) use ($value) {
+        $array = array_reduce($keys, function ($carry, $item) use ($value) {
             if (empty($carry)) {
                 $carry = $value;
             }
+
             return [$item => $carry];
         }, []);
 

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -416,5 +416,4 @@ class BrowsershotTest extends TestCase
             ],
         ], $command);
     }
-
 }

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -410,7 +410,7 @@ class BrowsershotTest extends TestCase
                 ],
                 'foo' => [
                     'bar' => 100,
-                    'baz' => 200
+                    'baz' => 200,
                 ],
             ],
         ], $command);

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -390,4 +390,29 @@ class BrowsershotTest extends TestCase
             ],
         ], $command);
     }
+
+    /** @test */
+    public function it_can_set_arbitrary_options()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->setOption('foo.bar', 100)
+            ->setOption('foo.baz', 200)
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'foo' => [
+                    'bar' => 100,
+                    'baz' => 200
+                ],
+            ],
+        ], $command);
+    }
 }

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -412,32 +412,9 @@ class BrowsershotTest extends TestCase
                     'bar' => 100,
                     'baz' => 200,
                 ],
+                'args' => [],
             ],
         ], $command);
     }
 
-    /** @test */
-    public function it_can_set_arbitrary_options()
-    {
-        $command = Browsershot::url('https://example.com')
-            ->setOption('foo.bar', 100)
-            ->setOption('foo.baz', 200)
-            ->createScreenshotCommand('screenshot.png');
-
-        $this->assertEquals([
-            'url' => 'https://example.com',
-            'action' => 'screenshot',
-            'options' => [
-                'path' => 'screenshot.png',
-                'viewport' => [
-                    'width' => 800,
-                    'height' => 600,
-                ],
-                'foo' => [
-                    'bar' => 100,
-                    'baz' => 200,
-                ],
-            ],
-        ], $command);
-    }
 }


### PR DESCRIPTION
This PR adds a `setOption($key, $value)` method which will allow users to pass options to Puppeteer that are not explicitly covered by the rest of this package.   

Options can be set using dot notation, like so: 

```php
Browsershot::url('https://example.com')
            ->showBackground()
            ->landscape()
            ->setOption('margin.top', '2cm')
            ->pages('1-3')
            ->paperSize(210, 148)
            ->createPdfCommand('screenshot.pdf');
```