### PR TITLE
Add delayed snapshot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,15 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
+#### Delayed screenshots
+You can delay execution of the screenshot by a specified amount of time by using `setDelay()`. This is useful if you need to wait for completion of javascript or if you are attempting to capture lazy-loaded resources. Delay time is measured in milliseconds.
+
+```php
+Browsershot::url('https://example.com')
+    ->setDelay(5000)
+    ->save($pathToImage);
+```
+
 ### PDFs
 
 Browsershot will save a pdf if the path passed to the `save` method has a `pdf` extension.

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -37,6 +37,10 @@ const callChrome = async () => {
 
         await page.goto(request.url, requestOptions);
 
+        if (request.options.delay) {
+            await page.waitFor(request.options.delay);
+        }
+
         console.log(await page[request.action](request.options));
 
         await browser.close();

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -23,6 +23,7 @@ class Browsershot
     protected $temporaryHtmlDirectory;
     protected $timeout = 60;
     protected $url = '';
+    protected $delay = 0;
     protected $additionalOptions = [];
 
     /** @var \Spatie\Image\Manipulations */
@@ -236,6 +237,13 @@ class Browsershot
             ->setOption('viewport.height', $height);
     }
 
+    public function setDelay(int $delay)
+    {
+        $this->delay = $delay;
+
+        return $this;
+    }
+
     public function setOption($key, $value)
     {
         $this->arraySet($this->additionalOptions, $key, $value);
@@ -319,6 +327,10 @@ class Browsershot
 
         if (! $this->showScreenshotBackground) {
             $command['options']['omitBackground'] = true;
+        }
+
+        if ($this->delay > 0) {
+            $command['options']['delay'] = $this->delay;
         }
 
         return $command;
@@ -443,5 +455,4 @@ class Browsershot
 
         return $array;
     }
-
 }

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -429,4 +429,18 @@ class BrowsershotTest extends TestCase
             ],
         ], $command);
     }
+
+    /** @test **/
+    public function it_can_add_a_delay_before_taking_a_screenshot()
+    {
+        $targetPath = __DIR__.'/temp/testScreenshot.png';
+        $delay = 5000;
+        $start = round(microtime(true) * 1000);
+        Browsershot::url('https://example.com')
+            ->setDelay($delay)
+            ->save($targetPath);
+        $end = round(microtime(true) * 1000);
+
+        $this->assertGreaterThanOrEqual($delay, $end - $start);
+    }
 }


### PR DESCRIPTION
Based on comments in #124 and #130, this PR adds the ability to set an optional delay on screenshot capture. This is useful when waiting for javascript or lazy-loaded resources to load before capturing. 

The included unit test is basically a best attempt at unit testing that. With potential network issues it's hard to guarantee that is always gonna be correct, without mocking a network request... which we can do if we need to.  