### PR TITLE
Add a way to set emulated media type page options

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,18 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
+#### Setting the CSS media type of the page
+
+
+You can also emulate the media type, especially usefull when you're generating pdf shots, because it will try to emulate the print version of the page by default.
+
+```php
+Browsershot::url('https://example.com')
+    ->emulateMedia('screen') // "screen", "print" (default) or null (passing null disables the emulation).
+    ->savePdf($pathToPdf);
+```
+
+
 The default timeout of Browsershot is set to 60 seconds. Of course, you can modify this timeout:
 
 ```php

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -24,6 +24,10 @@ const callChrome = async () => {
             await page.setUserAgent(request.options.userAgent);
         }
 
+        if (request.options && request.options.emulateMedia) {
+            await page.emulateMedia(request.options.emulateMedia);
+        }
+
         if (request.options && request.options.viewport) {
             await page.setViewport(request.options.viewport);
         }

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -228,11 +228,11 @@ class Browsershot
 
         return $this;
     }
-    
+
     public function emulateMedia(string $media)
     {
         $this->setOption('emulateMedia', $media);
-        
+
         return $this;
     }
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -228,6 +228,13 @@ class Browsershot
 
         return $this;
     }
+    
+    public function emulateMedia(string $media)
+    {
+        $this->setOption('emulateMedia', $media);
+        
+        return $this;
+    }
 
     public function windowSize(int $width, int $height)
     {

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -290,6 +290,28 @@ class BrowsershotTest extends TestCase
             ],
         ], $command);
     }
+    
+    /** @test */
+    public function it_can_set_emulate_media_option()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->emulateMedia('screen')
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'emulateMedia' => 'screen',
+                'args' => [],
+            ],
+        ], $command);
+    }
 
     /** @test */
     public function it_can_set_another_node_binary()

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -290,7 +290,7 @@ class BrowsershotTest extends TestCase
             ],
         ], $command);
     }
-    
+
     /** @test */
     public function it_can_set_emulate_media_option()
     {


### PR DESCRIPTION
Based on puppeteer's emulateMedia option this adds method to set it easily. Especially helpful when generating pdfs, because by default it is set to request 'print' CSS media type of pages.