### PR TITLE
Add "emulateMedia" option to page object

### DIFF
--- a/bin/browser.js
+++ b/bin/browser.js
@@ -27,6 +27,10 @@ const callChrome = async () => {
         if (request.options && request.options.viewport) {
             await page.setViewport(request.options.viewport);
         }
+        
+        if (request.options && request.options.emulateMedia) {
+            await page.emulateMedia(request.options.emulateMedia);
+        }
 
         const requestOptions = {};
 


### PR DESCRIPTION
This adds a way to request the CSS media type of the page. 
Because page.pdf() generates a pdf of the page with print css media. To generate a pdf with screen media, we can now call
```setOption('emulateMedia', 'screen')```