### PR TITLE
Output image or PDF to browser #140

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,14 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
+#### Output
+You can output the image directly to the browser using the `screenshot()` method.
+
+```php
+$image = Browsershot::url('https://example.com')
+    ->screenshot()
+```
+
 ### PDFs
 
 Browsershot will save a pdf if the path passed to the `save` method has a `pdf` extension.
@@ -293,6 +301,14 @@ You can control which pages should be export by passing a print range to the `pa
 Browsershot::html($someHtml)
    ->pages('1-5, 8, 11-13')
    ->save('example.pdf');
+```
+
+#### Output
+You can output the PDF directly to the browser using the `pdf()` method.
+
+```php
+$pdf = Browsershot::url('https://example.com')
+    ->pdf()
 ```
 
 ### HTML

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -5,6 +5,7 @@ const request = JSON.parse(process.argv[2]);
 const callChrome = async () => {
     let browser;
     let page;
+    let output;
 
     try {
         browser = await puppeteer.launch({
@@ -41,7 +42,16 @@ const callChrome = async () => {
             await page.waitFor(request.options.delay);
         }
 
-        console.log(await page[request.action](request.options));
+        output = await page[request.action](request.options);
+
+        if ( request.options.path )
+        {
+            console.log(output);
+        }
+        else
+        {
+            console.log(output.toString('base64'));
+        }
 
         await browser.close();
     } catch (exception) {

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -44,8 +44,7 @@ const callChrome = async () => {
 
         output = await page[request.action](request.options);
 
-        if ( !request.options.path )
-        {
+        if (!request.options.path) {
             console.log(output.toString('base64'));
         }
 

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -44,11 +44,7 @@ const callChrome = async () => {
 
         output = await page[request.action](request.options);
 
-        if ( request.options.path )
-        {
-            console.log(output);
-        }
-        else
+        if ( !request.options.path )
         {
             console.log(output.toString('base64'));
         }

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -289,7 +289,7 @@ class Browsershot
         return $this->callBrowser($command);
     }
 
-    public function screenshot()
+    public function screenshot(): string
     {
         $command = $this->createScreenshotCommand();
 
@@ -298,7 +298,7 @@ class Browsershot
         return base64_decode($encoded_image);
     }
 
-    public function pdf()
+    public function pdf(): string
     {
         $command = $this->createPdfCommand();
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -339,7 +339,7 @@ class Browsershot
         $url = $this->html ? $this->createTemporaryHtmlFile() : $this->url;
 
         $options = [];
-        if ( $targetPath ) {
+        if ($targetPath) {
             $options['path'] = $targetPath;
         }
 
@@ -357,7 +357,7 @@ class Browsershot
         $url = $this->html ? $this->createTemporaryHtmlFile() : $this->url;
 
         $options = [];
-        if ( $targetPath ) {
+        if ($targetPath) {
             $options['path'] = $targetPath;
         }
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -289,6 +289,24 @@ class Browsershot
         return $this->callBrowser($command);
     }
 
+    public function screenshot()
+    {
+        $command = $this->createScreenshotCommand();
+
+        $encoded_image = $this->callBrowser($command);
+
+        return base64_decode($encoded_image);
+    }
+
+    public function pdf()
+    {
+        $command = $this->createPdfCommand();
+
+        $encoded_pdf = $this->callBrowser($command);
+
+        return base64_decode($encoded_pdf);
+    }
+
     public function savePdf(string $targetPath)
     {
         $command = $this->createPdfCommand($targetPath);
@@ -316,11 +334,16 @@ class Browsershot
         return $this->createCommand($url, 'content');
     }
 
-    public function createScreenshotCommand(string $targetPath): array
+    public function createScreenshotCommand($targetPath = null): array
     {
         $url = $this->html ? $this->createTemporaryHtmlFile() : $this->url;
 
-        $command = $this->createCommand($url, 'screenshot', ['path' => $targetPath]);
+        $options = [];
+        if ( $targetPath ) {
+            $options['path'] = $targetPath;
+        }
+
+        $command = $this->createCommand($url, 'screenshot', $options);
 
         if (! $this->showScreenshotBackground) {
             $command['options']['omitBackground'] = true;
@@ -329,11 +352,16 @@ class Browsershot
         return $command;
     }
 
-    public function createPdfCommand($targetPath): array
+    public function createPdfCommand($targetPath = null): array
     {
         $url = $this->html ? $this->createTemporaryHtmlFile() : $this->url;
 
-        $command = $this->createCommand($url, 'pdf', ['path' => $targetPath]);
+        $options = [];
+        if ( $targetPath ) {
+            $options['path'] = $targetPath;
+        }
+
+        $command = $this->createCommand($url, 'pdf', $options);
 
         if ($this->showBackground) {
             $command['options']['printBackground'] = true;

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -447,4 +447,30 @@ class BrowsershotTest extends TestCase
 
         $this->assertGreaterThanOrEqual($delay, $end - $start);
     }
+
+    /** @test */
+    public function it_can_get_the_output_of_a_screenshot()
+    {
+        $output = Browsershot::url('https://example.com')
+            ->screenshot();
+
+        $finfo = finfo_open();
+
+        $mimeType = finfo_buffer($finfo, $output, FILEINFO_MIME_TYPE);
+
+        $this->assertEquals($mimeType, 'image/png');
+    }
+
+    /** @test */
+    public function it_can_get_the_output_of_a_pdf()
+    {
+        $output = Browsershot::url('https://example.com')
+            ->pdf();
+
+        $finfo = finfo_open();
+        
+        $mimeType = finfo_buffer($finfo, $output, FILEINFO_MIME_TYPE);
+
+        $this->assertEquals($mimeType, 'application/pdf');
+    }
 }

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -468,7 +468,7 @@ class BrowsershotTest extends TestCase
             ->pdf();
 
         $finfo = finfo_open();
-        
+
         $mimeType = finfo_buffer($finfo, $output, FILEINFO_MIME_TYPE);
 
         $this->assertEquals($mimeType, 'application/pdf');


### PR DESCRIPTION
Added 2 new methods `screenshot()` and `pdf()` to output the screenshot or PDF straight to the browser without having to create a new file.