### PR TITLE
Add ability to set node modules path

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ Browsershot::html('Foo')
 
 Setting the include path can be useful in cases where `node` and `npm` can not be found automatically.
 
+### Custom node module path
+
+If you want to use an alternative `node_modules` source you can set it using the `setNodeModulePath` method.
+
+```php
+Browsershot::html('Foo')
+  ->setNodeModulePath("/path/to/my/project/node_modules/")
+```
+
 ## Installation
 
 This package can be installed through Composer.

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -14,6 +14,7 @@ class Browsershot
 {
     protected $nodeBinary = null;
     protected $npmBinary = null;
+    protected $nodeModulePath = null;
     protected $includePath = '$PATH:/usr/local/bin';
     protected $html = '';
     protected $noSandbox = false;
@@ -74,6 +75,13 @@ class Browsershot
     public function setIncludePath(string $includePath)
     {
         $this->includePath = $includePath;
+
+        return $this;
+    }
+
+    public function setNodeModulePath(string $nodeModulePath)
+    {
+        $this->nodeModulePath = $nodeModulePath;
 
         return $this;
     }
@@ -416,6 +424,9 @@ class Browsershot
 
     protected function getNodePathCommand(string $nodeBinary): string
     {
+        if ($this->nodeModulePath) {
+            return "NODE_PATH='{$this->nodeModulePath}'";
+        }
         if ($this->npmBinary) {
             return "NODE_PATH=`{$nodeBinary} {$this->npmBinary} root -g`";
         }


### PR DESCRIPTION
I'd like to propose a new `setNodeModulePath()` method. This allows the specification of an alternate path for the `/node_modules/` directory. 

Here's my use case:

I'm work a screenshot capture tool that works inside of the Drupal CMS: [Web Page Archive](https://www.drupal.org/project/web_page_archive). 

The user can set their node/npm paths directly within the CMS. 

Drupal can really only guarantee write permissions on a few directories within the system. So I copy the package.json file into a separate directory and then runs `npm install` inside of that directory.  Thus the node_modules path gets added to that directory, not the root for `npm_path` which seems to be what Browsershot is currently defaulting to in this situation.

So for example, my code would look something this:

```php
    $screenCapture = Browsershot::url($data['url'])
      ->setNodeBinary($system_settings['node_path'])
      ->setNpmBinary($system_settings['npm_path'])
      ->setNodeModulePath("{$this->getNpmInstallDirectory()}/node_modules/")
      ->fullPage()
      ->setOption('viewport.width', (int) $this->configuration['width']);
```

Unfortunately, this is kind of hard to write tests for in the context of the `save()` method, and the `getNodePathCommand()` directory is currently `protected` so I can't test that method directly without doing some weird reflection stuff. If you have any advice on how to test it, I'm happy to add that in. 

In my opinion making `getNodePathCommand()` public would allow for direct tests of that method and probably suffice, but I didn't want to start changing scope of your code for this simple request. 