### PR TITLE
Add puppeteer chrome executable path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ Browsershot::html('Foo')
   ->setNodeModulePath("/path/to/my/project/node_modules/")
 ```
 
+### Custom chrome/chromium executable path
+
+If you want to use an alternative chrome or chromium executable from what is installed by puppeteer you can set it using the `setExecutablePath` method.
+
+```php
+Browsershot::html('Foo')
+  ->setExecutablePath("/path/to/my/chrome")
+```
+
 ## Installation
 
 This package can be installed through Composer.
@@ -339,7 +348,7 @@ Browsershot::url('https://example.com')
    ->setOption('landscape', true)
    ->save($pathToImage);
 ```
-  
+
 
 #### Setting the user agent
 

--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ Browsershot::html('Foo')
 
 ### Custom chrome/chromium executable path
 
-If you want to use an alternative chrome or chromium executable from what is installed by puppeteer you can set it using the `setExecutablePath` method.
+If you want to use an alternative chrome or chromium executable from what is installed by puppeteer you can set it using the `setChromePath` method.
 
 ```php
 Browsershot::html('Foo')
-  ->setExecutablePath("/path/to/my/chrome")
+  ->setChromePath("/path/to/my/chrome")
 ```
 
 ## Installation

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -10,6 +10,7 @@ const callChrome = async () => {
     try {
         browser = await puppeteer.launch({
             ignoreHTTPSErrors: request.options.ignoreHttpsErrors,
+            executablePath: request.options.executablePath,
             args: request.options.args || []
         });
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -86,6 +86,13 @@ class Browsershot
         return $this;
     }
 
+    public function setExecutablePath(string $executablePath)
+    {
+        $this->setOption('executablePath', $executablePath);
+
+        return $this;
+    }
+
     /**
      * @deprecated This option is no longer supported by modern versions of Puppeteer.
      */

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -86,7 +86,7 @@ class Browsershot
         return $this;
     }
 
-    public function setExecutablePath(string $executablePath)
+    public function setChromePath(string $executablePath)
     {
         $this->setOption('executablePath', $executablePath);
 

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -326,6 +326,18 @@ class BrowsershotTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_another_chrome_executable_path()
+    {
+        $this->expectException(ProcessFailedException::class);
+
+        $targetPath = __DIR__.'/temp/testScreenshot.png';
+
+        Browsershot::html('Foo')
+            ->setExecutablePath('non-existant/bin/wich/causes/an/exception')
+            ->save($targetPath);
+    }
+
+    /** @test */
     public function it_can_set_the_include_path_and_still_works()
     {
         $targetPath = __DIR__.'/temp/testScreenshot.png';

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -333,7 +333,7 @@ class BrowsershotTest extends TestCase
         $targetPath = __DIR__.'/temp/testScreenshot.png';
 
         Browsershot::html('Foo')
-            ->setExecutablePath('non-existant/bin/wich/causes/an/exception')
+            ->setChromePath('non-existant/bin/wich/causes/an/exception')
             ->save($targetPath);
     }
 


### PR DESCRIPTION
Per the [puppeteer api docs](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions), we can specify alternate executable path for chrome/chromium: 

>   - `executablePath` <[string]> Path to a Chromium executable to run instead of bundled Chromium. If `executablePath` is a relative path, then it is resolved relative to [current working directory](https://nodejs.org/api/process.html#process_process_cwd).

This PR adds support for this feature. 