### PR TITLE
Added "wait until network idle" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,17 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
+#### Waiting for lazy-loaded resources
+Some websites lazy-load additional resources via ajax or use webfonts, which might not be loaded in time for the screenshot. Using the `waitUntilNetworkIdle()` method you can tell Browsershot to wait for a period of 500 ms with no network activity before taking the screenshot, ensuring all additional resources are loaded.
+
+```php
+Browsershot::url('https://example.com')
+    ->waitUntilNetworkIdle()
+    ->save($pathToImage);
+```
+
+Alternatively you can use less strict `waitUntilNetworkIdle(false)`, which allows 2 network connections in the 500 ms waiting period, useful for websites with scripts periodically pinging an ajax endpoint.
+
 #### Delayed screenshots
 You can delay the taking of screenshot by  `setDelay()`. This is useful if you need to wait for completion of javascript or if you are attempting to capture lazy-loaded resources.
 

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -39,6 +39,8 @@ const callChrome = async () => {
         if (request.options && request.options.networkIdleTimeout) {
             requestOptions.waitUntil = 'networkidle';
             requestOptions.networkIdleTimeout = request.options.networkIdleTimeout;
+        } else if (request.options && request.options.waitUntil) {
+            requestOptions.waitUntil = request.options.waitUntil;
         }
 
         await page.goto(request.url, requestOptions);

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -103,6 +103,13 @@ class Browsershot
         return $this;
     }
 
+    public function waitUntilNetworkIdle(bool $strict = true)
+    {
+        $this->setOption('waitUntil', $strict ? 'networkidle0' : 'networkidle2');
+
+        return $this;
+    }
+
     public function setUrl(string $url)
     {
         $this->url = $url;

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -658,4 +658,44 @@ class BrowsershotTest extends TestCase
 
         $this->assertFileExists($targetPath);
     }
+
+    /** @test */
+    public function it_can_wait_until_network_idle()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->waitUntilNetworkIdle()
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'waitUntil' => 'networkidle0',
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [],
+            ],
+        ], $command);
+
+        $command = Browsershot::url('https://example.com')
+            ->waitUntilNetworkIdle($strict = false)
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'waitUntil' => 'networkidle2',
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [],
+            ],
+        ], $command);
+    }
 }


### PR DESCRIPTION
Hey, this PR adds a `waitUntilNetworkIdle()` option as a replacement for the old `setNetworkIdleTimeout()` option when using Puppeteer 1.x.

- `waitUntilNetworkIdle()` by default waits for the `networkidle0` event - no network connections for 500 ms
- `waitUntilNetworkIdle($strict = false)` waits for the `networkidle2` event - no more than 2 network connections for 500 ms (useful in edge cases where the website is pinging some ajax endpoint)

I believe this is in most cases better than using the delay option as with delay you are just guessing how long the resource loading will take, so you either waste time waiting or not waiting long enough. With network idle you are only waiting for an extra 500 ms in the best case.

Also I've found this required for webfonts to be properly rendered in some cases, not only SPAs.