### PR TITLE
Add support for taking screenshot of an element using a selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,14 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
+You can take a screenshot of an element matching a selector using `select`.
+
+```php
+Browsershot::url('https://example.com')
+    ->select('.some-selector')
+    ->save($pathToImage);
+```
+
 #### Manipulating the image
 
 You can use all the methods [spatie/image](https://docs.spatie.be/image/v1) provides. Here's an example where we create a greyscale image:

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -49,6 +49,15 @@ const callChrome = async () => {
             await page.waitFor(request.options.delay);
         }
 
+        if (request.options.selector) {
+            const element = await page.$(request.options.selector);
+            if(element === null) {
+                throw { type: 'ElementNotFound' };
+            }
+
+            request.options.clip = await element.boundingBox();
+        }
+
         output = await page[request.action](request.options);
 
         if (!request.options.path) {
@@ -62,6 +71,10 @@ const callChrome = async () => {
         }
 
         console.error(exception);
+
+        if(exception.type === 'ElementNotFound') {
+            process.exit(2);
+        }
 
         process.exit(1);
     }

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -6,6 +6,7 @@ use Spatie\Image\Image;
 use Spatie\Image\Manipulations;
 use Symfony\Component\Process\Process;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
+use Spatie\Browsershot\Exceptions\ElementNotFound;
 use Spatie\Browsershot\Exceptions\CouldNotTakeBrowsershot;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 
@@ -146,6 +147,11 @@ class Browsershot
     public function clip(int $x, int $y, int $width, int $height)
     {
         return $this->setOption('clip', compact('x', 'y', 'width', 'height'));
+    }
+
+    public function select($selector)
+    {
+        return $this->setOption('selector', $selector);
     }
 
     public function showBrowserHeaderAndFooter()
@@ -492,11 +498,15 @@ class Browsershot
 
         $process->run();
 
-        if (! $process->isSuccessful()) {
-            throw new ProcessFailedException($process);
+        if ($process->isSuccessful()) {
+            return $process->getOutput();
         }
 
-        return $process->getOutput();
+        if ($process->getExitCode() === 2) {
+            throw new ElementNotFound($this->additionalOptions['selector']);
+        }
+
+        throw new ProcessFailedException($process);
     }
 
     protected function getNodePathCommand(string $nodeBinary): string

--- a/src/Exceptions/ElementNotFound.php
+++ b/src/Exceptions/ElementNotFound.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Browsershot\Exceptions;
+
+use Exception;
+
+class ElementNotFound extends Exception
+{
+    public function __construct($selector)
+    {
+        parent::__construct("The given selector `{$selector} did not match any elements");
+    }
+}

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Browsershot\Test;
 
 use Spatie\Browsershot\Browsershot;
+use Spatie\Browsershot\Exceptions\ElementNotFound;
 use Spatie\Browsershot\Exceptions\CouldNotTakeBrowsershot;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 
@@ -94,6 +95,29 @@ class BrowsershotTest extends TestCase
             ->save($targetPath);
 
         $this->assertFileExists($targetPath);
+    }
+
+    /** @test */
+    public function it_can_take_a_screenshot_of_an_element_matching_a_selector()
+    {
+        $targetPath = __DIR__.'/temp/nodeScreenshot.png';
+
+        Browsershot::url('https://example.com')
+            ->select('div')
+            ->save($targetPath);
+
+        $this->assertFileExists($targetPath);
+    }
+
+    /** @test */
+    public function it_throws_an_exception_if_the_selector_does_not_match_any_elements()
+    {
+        $this->expectException(ElementNotFound::class);
+        $targetPath = __DIR__.'/temp/nodeScreenshot.png';
+
+        Browsershot::url('https://example.com')
+            ->select('not-a-valid-selector')
+            ->save($targetPath);
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds a new method `select` which can be used to capture a screenshot of an element matching a selector. It works by finding the [boundingBox](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#elementhandleboundingbox) of the element and using it to clip the screenshot.

A coupe things to note:
- If the selector does not match an element, ~~it is ignored~~ an exception is thrown
- it has no effect when creating a pdf, since `clip` is not supported when generating pdf files