### PR TITLE
Add extraHTTPHeaders options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `Browsershot` will be documented in this file
 
+### 3.18.0 - 2018-03-28
+
+- add support for taking screenshot of an element using a selector
+
 ### 3.17.0 - 2018-02-22
 
 - add support for custom binary/browser script

--- a/README.md
+++ b/README.md
@@ -461,6 +461,16 @@ Browsershot::url('https://example.com')
    ...
 ```
 
+#### Setting extraHTTPHeaders
+
+To send custom HTTP headers, set the extraHTTPHeaders option like so:
+
+```php
+Browsershot::url('https://example.com')
+    ->setExtraHTTPHeaders(['Custom-Header-Name' => 'Custom-Header-Value'])
+   ...
+```
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -34,6 +34,10 @@ const callChrome = async () => {
             await page.setViewport(request.options.viewport);
         }
 
+        if (request.options && request.options.extraHTTPHeaders) {
+            await page.setExtraHTTPHeaders(request.options.extraHTTPHeaders);
+        }
+
         const requestOptions = {};
 
         if (request.options && request.options.networkIdleTimeout) {

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -102,6 +102,13 @@ class Browsershot
         return $this;
     }
 
+    public function setExtraHTTPHeaders(array $extraHTTPHeaders)
+    {
+        $this->setOption('extraHTTPHeaders', $extraHTTPHeaders);
+
+        return $this;
+    }
+
     /**
      * @deprecated This option is no longer supported by modern versions of Puppeteer.
      */

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -755,6 +755,5 @@ class BrowsershotTest extends TestCase
                 'args' => [],
             ],
         ], $command);
-        ;
     }
 }

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -734,4 +734,27 @@ class BrowsershotTest extends TestCase
             ],
         ], $command);
     }
+
+    /** @test */
+    public function it_can_send_extra_http_headers()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->setExtraHTTPHeaders(['extra-http-header' => 'extra-http-header'])
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'extraHTTPHeaders' => ['extra-http-header' => 'extra-http-header'],
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [],
+            ],
+        ], $command);
+        ;
+    }
 }


### PR DESCRIPTION
Hi,
This PR allows to add HTTP headers to the page call using [extraHTTPHeaders](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetextrahttpheadersheaders) option. Fixes #171