### PR TITLE
Add click feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,16 @@ Browsershot::url('https://example.com')
    ...
 ```
 
+#### Clicking on the page
+
+You can specify clicks on the page.
+
+```php
+Browsershot::url('https://example.com')
+    ->click('#selector1')
+    ->click('#selector2', 'right', 5, 200) // Right click 5 times on #selector2, each click lasting 200 milliseconds.
+```
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -49,6 +49,17 @@ const callChrome = async () => {
 
         await page.goto(request.url, requestOptions);
 
+        if (request.options && request.options.clicks) {
+            for (let i = 0, len = request.options.clicks.length; i < len; i++) {
+                let clickOptions = request.options.clicks[i];
+                await page.click(clickOptions.selector, {
+                    'button': clickOptions.button,
+                    'clickCount': clickOptions.clickCount,
+                    'delay': clickOptions.delay,
+                });
+            }
+        }
+
         if (request.options.delay) {
             await page.waitFor(request.options.delay);
         }

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -109,6 +109,17 @@ class Browsershot
         return $this;
     }
 
+    public function click(string $selector, string $button = 'left', int $clickCount = 1, int $delay = 0)
+    {
+        $clicks = ($this->additionalOptions['clicks'] ?? []);
+
+        $clicks[] = compact('selector', 'button', 'clickCount', 'delay');
+
+        $this->setOption('clicks', $clicks);
+
+        return $this;
+    }
+
     /**
      * @deprecated This option is no longer supported by modern versions of Puppeteer.
      */

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -756,4 +756,40 @@ class BrowsershotTest extends TestCase
             ],
         ], $command);
     }
+
+    /** @test */
+    public function it_can_click_on_the_page()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->click('#selector1')
+            ->click('#selector2', 'right', 2, 1)
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'clicks' => [
+                    [
+                        'selector' => '#selector1',
+                        'button' => 'left',
+                        'clickCount' => 1,
+                        'delay' => 0,
+                    ],
+                    [
+                        'selector' => '#selector2',
+                        'button' => 'right',
+                        'clickCount' => 2,
+                        'delay' => 1,
+                    ],
+                ],
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [],
+            ],
+        ], $command);
+    }
 }


### PR DESCRIPTION
Hi,
This PR adds the [page.click](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pageclickselector-options) feature.
Fixes #174