### PR TITLE
Remove typehint from emulate media

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ addons:
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "spatie/image": "^1.4",
         "spatie/temporary-directory": "^1.1",
         "symfony/process": "^3.0|^4.0"

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -292,7 +292,7 @@ class Browsershot
         return $this;
     }
 
-    public function emulateMedia(string $media)
+    public function emulateMedia($media)
     {
         $this->setOption('emulateMedia', $media);
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -292,7 +292,7 @@ class Browsershot
         return $this;
     }
 
-    public function emulateMedia($media)
+    public function emulateMedia(?string $media)
     {
         $this->setOption('emulateMedia', $media);
 

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -478,6 +478,28 @@ class BrowsershotTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_emulate_media_option_to_null()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->emulateMedia(null)
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'emulateMedia' => null,
+                'args' => [],
+            ],
+        ], $command);
+    }
+
+    /** @test */
     public function it_can_set_another_node_binary()
     {
         $this->expectException(ProcessFailedException::class);


### PR DESCRIPTION
The docs suggest that you can set emulateMedia to null to remove emulation, however the emulateMedia method in browsershot is typehinted to a string so this option is not currently possible.  This PR fixes this by removing the typehint.