### PR TITLE
Fix typo in test where it checked the same thing twice

### DIFF
--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -522,7 +522,7 @@ class BrowsershotTest extends TestCase
         $targetPath = __DIR__.'/temp/testScreenshot.png';
 
         Browsershot::html('Foo')
-                   ->setChromePath('non-existant/bin/wich/causes/an/exception')
+                   ->setBinPath('non-existant/bin/wich/causes/an/exception')
                    ->save($targetPath);
     }
 


### PR DESCRIPTION
the test was there to test the wrong `setBinPath` and the `setChromePath` already existed 