### PR TITLE
Adds addStyleTag option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,16 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
+#### Adding CSS
+You can add CSS styles prior to your screenshot or output using the syntax for [Puppeteer's addStyleTag](https://github.com/GoogleChrome/puppeteer/blob/v1.9.0/docs/api.md#pageaddstyletagoptions).
+
+```php
+Browsershot::url('https://example.com')
+    ->setOption('addStyleTag', json_encode(['content' => 'body{ font-size: 14px; }']))
+    ->save($pathToImage);
+```
+
+
 #### Output directly to the browser
 You can output the image directly to the browser using the `screenshot()` method.
 

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -87,6 +87,10 @@ const callChrome = async () => {
             }
         }
 
+        if (request.options && request.options.addStyleTag) {
+			await page.addStyleTag( JSON.parse( request.options.addStyleTag ) );
+		}
+
         if (request.options.delay) {
             await page.waitFor(request.options.delay);
         }


### PR DESCRIPTION
Implements addStyleTag options supported by Puppeteer. https://github.com/GoogleChrome/puppeteer/blob/v1.9.0/docs/api.md#pageaddstyletagoptions

No PHP modified so no test updates included. I didn't see a JS unit suite.

Have been using this successfully over 4000 iterations with no issue so far. 

Thanks!
