### PR TITLE
Write options to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,17 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
+#### Writing options to file
+
+When the amount of options given to puppeteer becomes too big, Browsershot will fail because of an overflow of characters in the command line. 
+Browsershot can write the options to a file and pass that file to puppeteer and so bypass the character overflow.
+
+```php
+Browsershot::url('https://example.com')
+   ->writeOptionsToFile()
+   ...
+```
+
 ## Related packages
 
 * Laravel wrapper: [laravel-browsershot](https://github.com/verumconsilium/laravel-browsershot)

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -4,6 +4,12 @@ const URL = require('url').URL;
 
 const [, , ...args] = process.argv;
 
+/**
+ * There are two ways for Browsershot to communicate with puppeteer:
+ * - By giving a options JSON dump as an argument
+ * - Or by providing a temporary file with the options JSON dump,
+ *   the path to this file is then given as an argument with the flag -f
+ */
 const request = args[0].startsWith('-f ')
     ? JSON.parse(fs.readFileSync(new URL(args[0].substring(3))))
     : JSON.parse(args[0]);

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -1,6 +1,12 @@
 const puppeteer = require('puppeteer');
+const fs = require('fs');
+const URL = require('url').URL;
 
-const request = JSON.parse(process.argv[2]);
+const [, , ...args] = process.argv;
+
+const request = args[0].startsWith('-f ')
+    ? JSON.parse(fs.readFileSync(new URL(args[0].substring(3))))
+    : JSON.parse(args[0]);
 
 const getOutput = async (page, request) => {
     let output;
@@ -40,7 +46,7 @@ const callChrome = async () => {
             await page.setUserAgent(request.options.userAgent);
         }
 
-        if(request.options && request.options.device) {
+        if (request.options && request.options.device) {
             const devices = require('puppeteer/DeviceDescriptors');
             const device = devices[request.options.device];
             await page.emulate(device);
@@ -98,8 +104,8 @@ const callChrome = async () => {
         }
 
         if (request.options && request.options.addStyleTag) {
-			await page.addStyleTag( JSON.parse( request.options.addStyleTag ) );
-		}
+            await page.addStyleTag(JSON.parse(request.options.addStyleTag));
+        }
 
         if (request.options.delay) {
             await page.waitFor(request.options.delay);
@@ -107,8 +113,8 @@ const callChrome = async () => {
 
         if (request.options.selector) {
             const element = await page.$(request.options.selector);
-            if(element === null) {
-                throw { type: 'ElementNotFound' };
+            if (element === null) {
+                throw {type: 'ElementNotFound'};
             }
 
             request.options.clip = await element.boundingBox();
@@ -136,7 +142,7 @@ const callChrome = async () => {
 
         console.error(exception);
 
-        if(exception.type === 'ElementNotFound') {
+        if (exception.type === 'ElementNotFound') {
             process.exit(2);
         }
 

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1007,7 +1007,7 @@ class BrowsershotTest extends TestCase
     }
 
     /** @test */
-    public function it_can_write_options_to_a_file()
+    public function it_can_write_options_to_a_file_and_generate_a_screenshot()
     {
         $targetPath = __DIR__.'/temp/testScreenshot.png';
 
@@ -1016,5 +1016,19 @@ class BrowsershotTest extends TestCase
             ->save($targetPath);
 
         $this->assertFileExists($targetPath);
+    }
+
+    /** @test */
+    public function it_can_write_options_to_a_file_and_generate_a_pdf()
+    {
+        $targetPath = __DIR__.'/temp/testPdf.pdf';
+
+        Browsershot::url('https://example.com')
+            ->writeOptionsToFile()
+            ->save($targetPath);
+
+        $this->assertFileExists($targetPath);
+
+        $this->assertEquals('application/pdf', mime_content_type($targetPath));
     }
 }

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1005,4 +1005,16 @@ class BrowsershotTest extends TestCase
             ],
         ], $command);
     }
+
+    /** @test */
+    public function it_can_write_options_to_a_file()
+    {
+        $targetPath = __DIR__.'/temp/testScreenshot.png';
+
+        Browsershot::url('https://example.com')
+            ->writeOptionsToFile()
+            ->save($targetPath);
+
+        $this->assertFileExists($targetPath);
+    }
 }


### PR DESCRIPTION
This PR adds the ability to write the options given in Browsershot to a file instead of passing them as command line argument. When passing an options JSON to puppeteer that's too big(e.g. when you have an image as a header) the command line will crash because of a character overflow. We solve this by writing the options to a temporary file and passing the file as an argument instead of the whole JSON dump.