### PR TITLE
Feature custom papersize unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,21 +342,21 @@ Browsershot::html($someHtml)->savePdf('example.pdf');
 
 #### Sizing the pdf
 
-You can specify the width and the height in millimeters
+You can specify the width and the height in custom unit.
 
 ```php
 Browsershot::html($someHtml)
-   ->paperSize($width, $height)
+   ->paperSize($width, $height, 'mm')
    ->save('example.pdf');
 ```
 
 #### Setting margins
 
-Margins can be set in millimeters.
+Margins can be set in custom unit.
 
 ```php
 Browsershot::html($someHtml)
-   ->margins($top, $right, $bottom, $left)
+   ->margins($top, $right, $bottom, $left, 'mm')
    ->save('example.pdf');
 ```
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -305,13 +305,13 @@ class Browsershot
         return $this->setOption('landscape', $landscape);
     }
 
-    public function margins(int $top, int $right, int $bottom, int $left)
+    public function margins(float $top, float $right, float $bottom, float $left, string $unit = 'mm')
     {
         return $this->setOption('margin', [
-            'top' => $top.'mm',
-            'right' => $right.'mm',
-            'bottom' => $bottom.'mm',
-            'left' => $left.'mm',
+            'top' => $top.$unit,
+            'right' => $right.$unit,
+            'bottom' => $bottom.$unit,
+            'left' => $left.$unit,
         ]);
     }
 
@@ -332,11 +332,11 @@ class Browsershot
         return $this->setOption('pageRanges', $pages);
     }
 
-    public function paperSize(float $width, float $height)
+    public function paperSize(float $width, float $height, string $unit = 'mm')
     {
         return $this
-            ->setOption('width', $width.'mm')
-            ->setOption('height', $height.'mm');
+            ->setOption('width', $width.$unit)
+            ->setOption('height', $height.$unit);
     }
 
     // paper format

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1031,6 +1031,7 @@ class BrowsershotTest extends TestCase
 
         $this->assertEquals('application/pdf', mime_content_type($targetPath));
     }
+
     /** @test */
     public function it_can_generate_a_pdf_with_custom_paper_size_unit()
     {

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1031,4 +1031,33 @@ class BrowsershotTest extends TestCase
 
         $this->assertEquals('application/pdf', mime_content_type($targetPath));
     }
+    /** @test */
+    public function it_can_generate_a_pdf_with_custom_paper_size_unit()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->paperSize(8.3, 11.7, 'in')
+            ->margins(0.39, 0.78, 1.18, 1.57, 'in')
+            ->createPdfCommand('screenshot.pdf');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'pdf',
+            'options' => [
+                'path' => 'screenshot.pdf',
+                'margin' => [
+                    'top' => '0.39in',
+                    'right' => '0.78in',
+                    'bottom' => '1.18in',
+                    'left' => '1.57in',
+                ],
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'width' => '8.3in',
+                'height' => '11.7in',
+                'args' => [],
+            ],
+        ], $command);
+    }
 }


### PR DESCRIPTION
The `paperSize` and `margins` functions are hard coded as `mm`. It would be convenient to allow custom units.