### PR TITLE
Allow custom Chromium arguments to be passed on

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,33 @@ Browsershot::html('Foo')
 
 ### Pass custom arguments to Chromium
 
-If you need to pass custom arguments to Chromium, use the `addChromiumArg` method.
+If you need to pass custom arguments to Chromium, use the `addChromiumArguments` method.
 
-This can be useful to fix font rendering issues on some Linux distributions (e.g. CentOS).
+The method accepts an `array` of key/value pairs, or simply values. All of these arguments will automatically be prefixed with `--`.
 
 ```php
 Browsershot::html('Foo')
-  ->addChromiumArg('--font-render-hinting=none');
+  ->addChromiumArg([
+      'some-argument-without-a-value',
+      'keyed-argument' => 'argument-value',
+  ]);
+```
+
+If no key is provided, then the argument is passed through as-is.
+
+| Example array | Flags that will be passed to Chromium |
+| - | - |
+| `['foo']` | `--foo` |
+| `['foo', 'bar']` | `--foo --bar` |
+| `['foo', 'bar' => 'baz' ]` | `--foo --bar=baz` |
+
+This method can be useful in order to pass a flag to fix font rendering issues on some Linux distributions (e.g. CentOS).
+
+```php
+Browsershot::html('Foo')
+  ->addChromiumArg([
+      'font-render-hinting' => 'none',
+  ]);
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ Browsershot::html('Foo')
   ->setChromePath("/path/to/my/chrome")
 ```
 
+### Pass custom arguments to Chromium
+
+If you need to pass custom arguments to Chromium, use the `addChromiumArg` method.
+
+This can be useful to fix font rendering issues on some Linux distributions (e.g. CentOS).
+
+```php
+Browsershot::html('Foo')
+  ->addChromiumArg('--font-render-hinting=none');
+```
+
 ## Installation
 
 This package can be installed through Composer.

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -31,6 +31,7 @@ class Browsershot
     protected $additionalOptions = [];
     protected $temporaryOptionsDirectory;
     protected $writeOptionsToFile = false;
+    protected $chromiumArgs = [];
 
     /** @var \Spatie\Image\Manipulations */
     protected $imageManipulations;
@@ -416,6 +417,13 @@ class Browsershot
         return $this;
     }
 
+    public function addChromiumArg(string $argument)
+    {
+        $this->chromiumArgs[] = $argument;
+
+        return $this;
+    }
+
     public function __call($name, $arguments)
     {
         $this->imageManipulations->$name(...$arguments);
@@ -564,7 +572,7 @@ class Browsershot
 
     protected function getOptionArgs(): array
     {
-        $args = [];
+        $args = $this->chromiumArgs;
 
         if ($this->noSandbox) {
             $args[] = '--no-sandbox';

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -426,6 +426,7 @@ class Browsershot
                 $this->chromiumArgs[] = "--$argument=$value";
             }
         }
+
         return $this;
     }
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -417,10 +417,15 @@ class Browsershot
         return $this;
     }
 
-    public function addChromiumArg(string $argument)
+    public function addChromiumArguments(array $arguments)
     {
-        $this->chromiumArgs[] = $argument;
-
+        foreach ($arguments as $argument => $value) {
+            if (is_numeric($argument)) {
+                $this->chromiumArgs[] = "--$value";
+            } else {
+                $this->chromiumArgs[] = "--$argument=$value";
+            }
+        }
         return $this;
     }
 

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1102,4 +1102,54 @@ class BrowsershotTest extends TestCase
             ],
         ], $command);
     }
+
+    /** @test */
+    public function it_will_pass_on_a_single_added_chromium_arg()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->addChromiumArg('--my-custom-arg=foobar')
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [
+                    '--my-custom-arg=foobar',
+                ],
+                'type' => 'png',
+            ],
+        ], $command);
+    }
+
+    /** @test */
+    public function it_will_pass_on_multiple_added_chromium_args()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->addChromiumArg('--my-custom-arg=foobar')
+            ->addChromiumArg('--another-arg')
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [
+                    '--my-custom-arg=foobar',
+                    '--another-arg',
+                ],
+                'type' => 'png',
+            ],
+        ], $command);
+    }
 }

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1150,7 +1150,7 @@ class BrowsershotTest extends TestCase
                 'args' => [
                     '--my-custom-arg',
                     '--another-argument=some-value',
-                    '--yet-another-arg=foo'
+                    '--yet-another-arg=foo',
                 ],
                 'type' => 'png',
             ],

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1104,10 +1104,10 @@ class BrowsershotTest extends TestCase
     }
 
     /** @test */
-    public function it_will_pass_on_a_single_added_chromium_arg()
+    public function it_will_auto_prefix_chromium_arguments()
     {
         $command = Browsershot::url('https://example.com')
-            ->addChromiumArg('--my-custom-arg=foobar')
+            ->addChromiumArguments(['please-autoprefix-me'])
             ->createScreenshotCommand('screenshot.png');
 
         $this->assertEquals([
@@ -1120,7 +1120,7 @@ class BrowsershotTest extends TestCase
                     'height' => 600,
                 ],
                 'args' => [
-                    '--my-custom-arg=foobar',
+                    '--please-autoprefix-me',
                 ],
                 'type' => 'png',
             ],
@@ -1128,11 +1128,14 @@ class BrowsershotTest extends TestCase
     }
 
     /** @test */
-    public function it_will_pass_on_multiple_added_chromium_args()
+    public function it_will_allow_many_chromium_arguments()
     {
         $command = Browsershot::url('https://example.com')
-            ->addChromiumArg('--my-custom-arg=foobar')
-            ->addChromiumArg('--another-arg')
+            ->addChromiumArguments([
+                'my-custom-arg',
+                'another-argument' => 'some-value',
+                'yet-another-arg' => 'foo',
+            ])
             ->createScreenshotCommand('screenshot.png');
 
         $this->assertEquals([
@@ -1145,8 +1148,9 @@ class BrowsershotTest extends TestCase
                     'height' => 600,
                 ],
                 'args' => [
-                    '--my-custom-arg=foobar',
-                    '--another-arg',
+                    '--my-custom-arg',
+                    '--another-argument=some-value',
+                    '--yet-another-arg=foo'
                 ],
                 'type' => 'png',
             ],


### PR DESCRIPTION
Adds the ability to set some custom arguments that will be passed onto Chromium when it is launched.

We required the ability to do this as running Chromium on our CentOS server caused some super bizarre font rendering issues unless we passed on an explicit font hinting flag to Chromium.

Any problems, let me know.

Thanks

👍 