### PR TITLE
feat: allow javascript to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,16 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
+#### Disable Javascript
+If you want to completely disable javascript when capturing the page, use the `disableJavascript()` method.  
+Be aware that some sites will not render correctly without javascript.
+
+```php
+Browsershot::url('https://example.com')
+    ->disableJavascript()
+    ->save($pathToImage);
+```
+
 #### Waiting for lazy-loaded resources
 Some websites lazy-load additional resources via ajax or use webfonts, which might not be loaded in time for the screenshot. Using the `waitUntilNetworkIdle()` method you can tell Browsershot to wait for a period of 500 ms with no network activity before taking the screenshot, ensuring all additional resources are loaded.
 

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -42,6 +42,10 @@ const callChrome = async () => {
 
         page = await browser.newPage();
 
+        if (request.options && request.options.disableJavascript) {
+            await page.setJavaScriptEnabled(false);
+        }
+
         if (request.options && request.options.dismissDialogs) {
             page.on('dialog', async dialog => {
                 await dialog.dismiss();

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -339,6 +339,11 @@ class Browsershot
         return $this->setOption('dismissDialogs', true);
     }
 
+    public function disableJavascript()
+    {
+        return $this->setOption('disableJavascript', true);
+    }
+
     public function pages(string $pages)
     {
         return $this->setOption('pageRanges', $pages);

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -586,6 +586,29 @@ class BrowsershotTest extends TestCase
     }
 
     /** @test */
+    public function it_can_disable_javascript()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->disableJavascript()
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'disableJavascript' => true,
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [],
+                'type' => 'png',
+            ],
+        ], $command);
+    }
+
+    /** @test */
     public function it_can_ignore_https_errors()
     {
         $command = Browsershot::url('https://example.com')


### PR DESCRIPTION
As per #280 this add an option to the package that allows you to disable javascript when capturing pages.

Let me know if you have any issues/suggestions :smile: 