### PR TITLE
Feature/specify-cookie-domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,14 @@ Browsershot::url('https://example.com')
    ...
 ```
 
+You can specify the domain to register cookies to, if necessary:
+
+```php
+Browsershot::url('https://example.com')
+    ->useCookies(['Cookie-Key' => 'Cookie-Value'], 'ui.example.com')
+   ...
+```
+
 #### Clicking on the page
 
 You can specify clicks on the page.

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -112,17 +112,23 @@ class Browsershot
         return $this;
     }
 
-    public function useCookies(array $cookies)
+    public function useCookies(array $cookies, string $domain = null)
     {
         if (! count($cookies)) {
             return $this;
         }
 
-        $domain = parse_url($this->url)['host'];
+        if (is_null($domain)) {
+            $domain = parse_url($this->url)['host'];
+        }
 
         $cookies = array_map(function ($value, $name) use ($domain) {
             return compact('name', 'value', 'domain');
         }, $cookies, array_keys($cookies));
+
+        if (isset($this->additionalOptions['cookies'])) {
+            $cookies = array_merge($this->additionalOptions['cookies'], $cookies);
+        }
 
         $this->setOption('cookies', $cookies);
 

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -808,6 +808,7 @@ class BrowsershotTest extends TestCase
     {
         $command = Browsershot::url('https://example.com')
             ->useCookies(['theme' => 'light', 'sessionToken' => 'abc123'])
+            ->useCookies(['theme' => 'dark'], 'ui.example.com')
             ->createScreenshotCommand('screenshot.png');
 
         $this->assertEquals([
@@ -824,6 +825,11 @@ class BrowsershotTest extends TestCase
                         'name' => 'sessionToken',
                         'value' => 'abc123',
                         'domain' => 'example.com',
+                    ],
+                    [
+                        'name' => 'theme',
+                        'value' => 'dark',
+                        'domain' => 'ui.example.com',
                     ],
                 ],
                 'path' => 'screenshot.png',


### PR DESCRIPTION
Allows the domain to be specified when adding cookies via the `useCookies` method.

Note that it may be necessary for a developer to specify cookies for multiple domains in the same request. For this reason, the cookies passed through this method will merge rather than overwrite the previous `cookies` entry. The alternative would be to specify the domain for each cookie as it is passed in, however, that would incur a breaking change.

Fixes #304 