### PR TITLE
Fix pdf (in-memory) not deleting temporary file on filesystem

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -514,7 +514,9 @@ class Browsershot
     {
         $command = $this->createPdfCommand();
 
-        $encoded_pdf = $this->callBrowser($command);
+		$encoded_pdf = $this->callBrowser($command);
+		
+		$this->cleanupTemporaryHtmlFile();
 
         return base64_decode($encoded_pdf);
     }


### PR DESCRIPTION
Currently, only savePdf() will delete temporary files while generating PDF, pdf() won't.

This commit only add cleanupTemporaryHtmlFile() after PDF has been generated and grabbed in base64.