### PR TITLE
Connect to remote chromium instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Browsershot::url('https://example.com')->save($pathToImage);
 ```
 
 #### Formatting the image
-By default the screenshot's type will be a `png`. (According to [Puppeteer's Config](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagescreenshotoptions))  
+By default the screenshot's type will be a `png`. (According to [Puppeteer's Config](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagescreenshotoptions))
 But you can change it to `jpeg` with quality option.
 
 ```php
@@ -304,7 +304,7 @@ Browsershot::url('https://example.com')
 ```
 
 #### Disable Javascript
-If you want to completely disable javascript when capturing the page, use the `disableJavascript()` method.  
+If you want to completely disable javascript when capturing the page, use the `disableJavascript()` method.
 Be aware that some sites will not render correctly without javascript.
 
 ```php
@@ -540,7 +540,7 @@ Browsershot::url('https://example.com')
 
 #### Changing the language of the browser
 
-You can use `setOption` to change the language of the browser.  
+You can use `setOption` to change the language of the browser.
 In order to load a page in a specific language for example.
 
 ```php
@@ -653,7 +653,7 @@ You can specify clicks on the page.
 Browsershot::url('https://example.com')
     ->click('#selector1')
     // Right click 5 times on #selector2, each click lasting 200 milliseconds.
-    ->click('#selector2', 'right', 5, 200) 
+    ->click('#selector2', 'right', 5, 200)
 ```
 
 #### Typing on the page
@@ -697,12 +697,22 @@ Browsershot::url('https://example.com')
 
 #### Writing options to file
 
-When the amount of options given to puppeteer becomes too big, Browsershot will fail because of an overflow of characters in the command line. 
+When the amount of options given to puppeteer becomes too big, Browsershot will fail because of an overflow of characters in the command line.
 Browsershot can write the options to a file and pass that file to puppeteer and so bypass the character overflow.
 
 ```php
 Browsershot::url('https://example.com')
    ->writeOptionsToFile()
+   ...
+```
+
+#### Connection to a remote chromium/chrome instance
+
+If you have a remote endpoint for a running chromium/chrome instance, properly configured with the param --remote-debugging-port, you can connect to it using the method `setRemoteInstance`. You only need to specify it's ip and port (defaults are 127.0.0.1 and 9222 accordingly). If no instance is available at the given endpoint (instance crashed, restarting instance, etc), this will fallback to launching a chromium instance.
+
+```php
+Browsershot::url('https://example.com')
+   ->setRemoteInstance('1.2.3.4', 9222)
    ...
 ```
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -608,6 +608,16 @@ class Browsershot
         return $this->createCommand($url, 'evaluate', $options);
     }
 
+    public function setRemoteInstance(string $ip = '127.0.0.1', int $port = 9222) : self
+    {
+        // assuring that ip and port does actually contains a value
+        if ($ip && $port) {
+            $this->setOption('remoteInstanceUrl', 'http://'.$ip.':'.$port);
+        }
+
+        return $this;
+    }
+
     protected function getOptionArgs(): array
     {
         $args = $this->chromiumArguments;

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1226,4 +1226,70 @@ class BrowsershotTest extends TestCase
         $this->assertEquals(200, getimagesize($targetPath)[0]);
         $this->assertEquals(200, getimagesize($targetPath)[1]);
     }
+
+    /** @test */
+    public function it_will_connect_to_remote_instance_and_take_screenshot()
+    {
+        $instance = Browsershot::url('https://example.com')
+            ->setRemoteInstance();
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [],
+                'type' => 'png',
+                'remoteInstanceUrl' => 'http://127.0.0.1:9222',
+            ],
+        ], $instance->createScreenshotCommand('screenshot.png'));
+
+        /*
+         * to test the connection, uncomment the following code, and make sure you are running a chrome/chromium instance locally,
+         * with the following param: --headless --remote-debugging-port=9222
+         */
+        /*
+        $targetPath = __DIR__.'/temp/testScreenshot.png';
+
+        file_put_contents($targetPath, $instance->screenshot());
+        $this->assertFileExists($targetPath);
+        */
+    }
+
+    /** @test */
+    public function it_will_connect_to_a_custom_remote_instance_and_take_screenshot()
+    {
+        $instance = Browsershot::url('https://example.com')
+            ->setRemoteInstance('127.0.0.1', 9999);
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [],
+                'type' => 'png',
+                'remoteInstanceUrl' => 'http://127.0.0.1:9999',
+            ],
+        ], $instance->createScreenshotCommand('screenshot.png'));
+
+        /*
+        * to test the connection, uncomment the following code, and make sure you are running a chrome/chromium instance locally,
+        * with the following params: --headless --remote-debugging-port=9999
+        */
+        /*
+        $targetPath = __DIR__.'/temp/testScreenshot.png';
+
+        file_put_contents($targetPath, $instance->screenshot());
+        $this->assertFileExists($targetPath);
+        */
+    }
 }


### PR DESCRIPTION
This PR adds a method to the current API, allowing the configuration of a remote chromium/chrome instance. This instance needs to be running with the following parameter: --remote-debugging-port=<port goes here, default is 9222>

I also modified browser.js to use the connect method of puppeteer. Using the parameter browserURL,  puppeteer will connect with that instance, returning a browser instance, just like using the launch method. If for some reason that instance is not running, browsershot will fallback to launching a chromium instance, continuing is normal flow.

Also i added disconnect methods to browser instance when ending the browser.js script. The page instance is also being closed so the instance is kept clean after running jobs.

I also made some tests, but part of them are commented out, because they need two chromium/chrome instances running. I added description on how to proceed to test the connection part.

I also updated the README describing the behavior of setRemoteInstance.

