### PR TITLE
Adds disableImages method to prevent images from loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,15 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
+#### Disable Images
+You can completely remove all images and <img> elements when capturing a page using the `disableImages()` method.
+
+```php
+Browsershot::url('https://example.com')
+    ->disableImages()
+    ->save($pathToImage);
+```
+
 #### Waiting for lazy-loaded resources
 Some websites lazy-load additional resources via ajax or use webfonts, which might not be loaded in time for the screenshot. Using the `waitUntilNetworkIdle()` method you can tell Browsershot to wait for a period of 500 ms with no network activity before taking the screenshot, ensuring all additional resources are loaded.
 

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -61,6 +61,16 @@ const callChrome = async () => {
             await page.setJavaScriptEnabled(false);
         }
 
+        if (request.options && request.options.disableImages) {
+            await page.setRequestInterception(true);
+            page.on('request', request => {
+                if (request.resourceType() === 'image')
+                    request.abort();
+                else
+                    request.continue();
+            });
+        }
+
         if (request.options && request.options.dismissDialogs) {
             page.on('dialog', async dialog => {
                 await dialog.dismiss();
@@ -111,6 +121,15 @@ const callChrome = async () => {
         }
 
         await page.goto(request.url, requestOptions);
+
+        if (request.options && request.options.disableImages) {
+            await page.evaluate(() => {
+                let images = document.getElementsByTagName('img');
+                while (images.length > 0) {
+                    images[0].parentNode.removeChild(images[0]);
+                }
+            });
+        }
 
         if (request.options && request.options.types) {
             for (let i = 0, len = request.options.types.length; i < len; i++) {

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -357,6 +357,11 @@ class Browsershot
         return $this->setOption('disableJavascript', true);
     }
 
+    public function disableImages()
+    {
+        return $this->setOption('disableImages', true);
+    }
+
     public function pages(string $pages)
     {
         return $this->setOption('pageRanges', $pages);

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -610,6 +610,29 @@ class BrowsershotTest extends TestCase
     }
 
     /** @test */
+    public function it_can_disable_images()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->disableImages()
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'disableImages' => true,
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [],
+                'type' => 'png',
+            ],
+        ], $command);
+    }
+
+    /** @test */
     public function it_can_ignore_https_errors()
     {
         $command = Browsershot::url('https://example.com')


### PR DESCRIPTION
I've seen a few HTML to PDF APIs that have this functionality, so I figured I'd try and add it in. 

It uses [an example](https://github.com/puppeteer/puppeteer/blob/master/examples/block-images.js) from Puppeteer's repo to block the actual image requests, and a small loop to go through the DOM and remove all `<img>` elements after the page has been fetched.