### PR TITLE
Add use of WS Endpoint option

### DIFF
--- a/bin/browser.js
+++ b/bin/browser.js
@@ -36,12 +36,21 @@ const callChrome = async () => {
     let remoteInstance;
 
     try {
-        if (request.options.remoteInstanceUrl) {
+        if (request.options.remoteInstanceUrl || request.options.browserWSEndpoint ) {
+            // default options
+            let options = {
+                ignoreHTTPSErrors: request.options.ignoreHttpsErrors
+            };
+
+            // choose only one method to connect to the browser instance
+            if ( request.options.remoteInstanceUrl ) {
+                options.browserURL = request.options.remoteInstanceUrl;
+            } else if ( request.options.browserWSEndpoint ) {
+                options.browserWSEndpoint = request.options.browserWSEndpoint;
+            }
+
             try {
-                browser = await puppeteer.connect({
-                    browserURL: request.options.remoteInstanceUrl,
-                    ignoreHTTPSErrors: request.options.ignoreHttpsErrors
-                });
+                browser = await puppeteer.connect( options );
 
                 remoteInstance = true;
             } catch (exception) { /** does nothing. fallbacks to launching a chromium instance */}

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -633,6 +633,15 @@ class Browsershot
         return $this;
     }
 
+    public function setWSEndpoint(string $endpoint): self
+    {
+        if (! is_null($endpoint)) {
+            $this->setOption('browserWSEndpoint', $endpoint);
+        }
+
+        return $this;
+    }
+
     protected function getOptionArgs(): array
     {
         $args = $this->chromiumArguments;

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1315,4 +1315,42 @@ class BrowsershotTest extends TestCase
         $this->assertFileExists($targetPath);
         */
     }
+
+    /** @test */
+    public function it_will_connect_to_a_custom_ws_endpoint_and_take_screenshot()
+    {
+        $instance = Browsershot::url('https://example.com')
+            ->setWSEndpoint('wss://chrome.browserless.io/');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [],
+                'type' => 'png',
+                'browserWSEndpoint' => 'wss://chrome.browserless.io/',
+            ],
+        ], $instance->createScreenshotCommand('screenshot.png'));
+
+        // It should be online so mis-use the assetsContains because a 4xx error won't contain the word "browerless".
+        $html = Browsershot::url('https://browserless.io')
+            ->bodyHtml();
+
+        // If it's offline then this will fail.
+        $this->assertContains('browserless', $html);
+
+        /* Now that we now the domain is online, assert the screenshot.
+         * Although we can't be sure, because Browsershot itself falls back to launching a chromium instance in browser.js
+        */
+
+        $targetPath = __DIR__.'/temp/testScreenshot.png';
+
+        file_put_contents($targetPath, $instance->screenshot());
+        $this->assertFileExists($targetPath);
+    }
 }

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1338,11 +1338,11 @@ class BrowsershotTest extends TestCase
         ], $instance->createScreenshotCommand('screenshot.png'));
 
         // It should be online so mis-use the assetsContains because a 4xx error won't contain the word "browerless".
-        $html = Browsershot::url('https://browserless.io')
+        $html = Browsershot::url('https://chrome.browserless.io/json/')
             ->bodyHtml();
 
         // If it's offline then this will fail.
-        $this->assertContains('browserless', $html);
+        $this->assertContains('chrome.browserless.io', $html);
 
         /* Now that we now the domain is online, assert the screenshot.
          * Although we can't be sure, because Browsershot itself falls back to launching a chromium instance in browser.js


### PR DESCRIPTION
First of all, thank you very much for this lib. Works like a charm. 

# Background
Are you open to introducing the option "browserWSEndpoint" while using `puppeteer.connect`. I'm using https://www.browserless.io/ and that works by settings the `browserWSEndpoint` value like:

```
const browser = await puppeteer.connect({
  browserWSEndpoint: 'wss://chrome.browserless.io/'
});
```

They don't have an way to work with the `browserURL` option so hench the PR.

# Unit test
As far as the unit test I wrote. I don't know if you would like it to be enable by default? It depends on this external service to be online. We can either comment it out like the "remoteInstance" tests or keep it like this. Your call.

I do have added a test / assets to check of the WS Endpoint is online by just doing a `assetsContains` on the url instead of trying to code this with some `curl` code or so. 
I could have set up a whole new Guzzle client and do a proper request, but it didn't matter to me if the return request was JSON. I just wanted to know if the url is online.

Let me know how you feel about this all.

Kinds regards,

Jaime Martinez
