### PR TITLE
[feature] Get the list of triggered requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ Browsershot also can get the body of an html page after JavaScript has been exec
 Browsershot::url('https://example.com')->bodyHtml(); // returns the html of the body
 ```
 
+If you wish to retrieve a JSON list of all of the requests that the page triggered you can do so:
+
+```php
+$response = Browsershot::url('https://example.com')->triggeredRequest();
+
+$requests = json_decode($response, true);
+
+foreach ($requests as $request) {
+    $url = $request['url']; //https://example.com/
+}
+```
+
+**`triggeredRequests()` works well with `waitUntilNetworkIdle` as described [here](#waiting-for-lazy-loaded-resources)**
+
 ## Support us
 
 Learn how to create a package like this one, by watching our premium video course:

--- a/README.md
+++ b/README.md
@@ -35,12 +35,11 @@ Browsershot also can get the body of an html page after JavaScript has been exec
 Browsershot::url('https://example.com')->bodyHtml(); // returns the html of the body
 ```
 
-If you wish to retrieve a JSON list of all of the requests that the page triggered you can do so:
+If you wish to retrieve an array list with all of the requests that the page triggered you can do so:
 
 ```php
-$response = Browsershot::url('https://example.com')->triggeredRequest();
-
-$requests = json_decode($response, true);
+$requests = Browsershot::url('https://example.com')
+    ->triggeredRequests();
 
 foreach ($requests as $request) {
     $url = $request['url']; //https://example.com/

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -80,8 +80,8 @@ const callChrome = async () => {
                     request.continue();
             });
         }
-        
-        if (request.options && request.options.blockDomains) { 
+
+        if (request.options && request.options.blockDomains) {
             await page.setRequestInterception(true);
             var domainsArray = JSON.parse(request.options.blockDomains);
             page.on('request', request => {
@@ -93,7 +93,7 @@ const callChrome = async () => {
             });
         }
 
-        if (request.options && request.options.blockUrls) { 
+        if (request.options && request.options.blockUrls) {
             await page.setRequestInterception(true);
             var urlsArray = JSON.parse(request.options.blockUrls);
             page.on('request', request => {
@@ -103,7 +103,7 @@ const callChrome = async () => {
                 request.continue();
             });
         }
-        
+
         if (request.options && request.options.dismissDialogs) {
             page.on('dialog', async dialog => {
                 await dialog.dismiss();

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -15,8 +15,16 @@ const request = args[0].startsWith('-f ')
     ? JSON.parse(fs.readFileSync(new URL(args[0].substring(3))))
     : JSON.parse(args[0]);
 
+const requestsList = [];
+
 const getOutput = async (page, request) => {
     let output;
+
+    if (request.action == 'requestsList') {
+        output = JSON.stringify(requestsList);
+
+        return output;
+    }
 
     if (request.action == 'evaluate') {
         output = await page.evaluate(request.options.pageFunction);
@@ -64,15 +72,22 @@ const callChrome = async () => {
             });
         }
 
-
         page = await browser.newPage();
 
         if (request.options && request.options.disableJavascript) {
             await page.setJavaScriptEnabled(false);
         }
 
+        await page.setRequestInterception(true);
+
+        page.on('request', request => {
+            requestsList.push({
+                url: request.url(),
+            });
+            request.continue();
+        });
+
         if (request.options && request.options.disableImages) {
-            await page.setRequestInterception(true);
             page.on('request', request => {
                 if (request.resourceType() === 'image')
                     request.abort();
@@ -82,7 +97,6 @@ const callChrome = async () => {
         }
 
         if (request.options && request.options.blockDomains) {
-            await page.setRequestInterception(true);
             var domainsArray = JSON.parse(request.options.blockDomains);
             page.on('request', request => {
                 const hostname = URLParse(request.url()).hostname;
@@ -94,7 +108,6 @@ const callChrome = async () => {
         }
 
         if (request.options && request.options.blockUrls) {
-            await page.setRequestInterception(true);
             var urlsArray = JSON.parse(request.options.blockUrls);
             page.on('request', request => {
                 urlsArray.forEach(function(value){

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -560,9 +560,7 @@ class Browsershot
     {
         $command = $this->createTriggeredRequestsListCommand();
 
-        $list = @json_decode($this->callBrowser($command), true);
-
-        return $list ?: [];
+        return json_decode($this->callBrowser($command), true);
     }
 
     public function applyManipulations(string $imagePath)

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -556,11 +556,13 @@ class Browsershot
         return $this->callBrowser($command);
     }
 
-    public function triggeredRequests(): string
+    public function triggeredRequests(): array
     {
         $command = $this->createTriggeredRequestsListCommand();
 
-        return $this->callBrowser($command);
+        $list = @json_decode($this->callBrowser($command), true);
+
+        return $list ?: [];
     }
 
     public function applyManipulations(string $imagePath)

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -556,6 +556,13 @@ class Browsershot
         return $this->callBrowser($command);
     }
 
+    public function triggeredRequests(): string
+    {
+        $command = $this->createTriggeredRequestsListCommand();
+
+        return $this->callBrowser($command);
+    }
+
     public function applyManipulations(string $imagePath)
     {
         Image::load($imagePath)
@@ -621,6 +628,13 @@ class Browsershot
         ];
 
         return $this->createCommand($url, 'evaluate', $options);
+    }
+
+    public function createTriggeredRequestsListCommand(): array
+    {
+        $url = $this->html ? $this->createTemporaryHtmlFile() : $this->url;
+
+        return $this->createCommand($url, 'requestsList');
     }
 
     public function setRemoteInstance(string $ip = '127.0.0.1', int $port = 9222): self

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -25,6 +25,17 @@ class BrowsershotTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_requests_list()
+    {
+        $listAsString = Browsershot::url('https://example.com')
+            ->triggeredRequests();
+
+        $listAsArray = @json_decode($listAsString, true);
+
+        $this->assertEquals('https://example.com/', $listAsArray[0]['url']);
+    }
+
+    /** @test */
     public function it_can_take_a_screenshot()
     {
         $targetPath = __DIR__.'/temp/testScreenshot.png';

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -33,8 +33,8 @@ class BrowsershotTest extends TestCase
         $this->assertCount(1, $list);
 
         $this->assertEquals(
-            ['url' => 'https://example.com/'],
-            $list[0]['url']
+            [['url' => 'https://example.com/']],
+            $list
         );
     }
 

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -27,12 +27,15 @@ class BrowsershotTest extends TestCase
     /** @test */
     public function it_can_get_the_requests_list()
     {
-        $listAsString = Browsershot::url('https://example.com')
+        $list = Browsershot::url('https://example.com')
             ->triggeredRequests();
 
-        $listAsArray = @json_decode($listAsString, true);
+        $this->assertCount(1, $list);
 
-        $this->assertEquals('https://example.com/', $listAsArray[0]['url']);
+        $this->assertEquals(
+            ['url' => 'https://example.com/'],
+            $list[0]['url']
+        );
     }
 
     /** @test */


### PR DESCRIPTION
Each request made to a website can trigger more requests, like loading the CSS files & everything. You are able to block certain ones, but you can't get a list of them.

This PR adds a new `triggeredRequests()` function that outputs a JSON string with all of the loaded URLs.

~~It can later be transformed into an array as stated in the readme.~~

Apart from `url`, I don't know what other data might be needed and that can be added to the list.