### PR TITLE
Account for the removal of require('puppeteer/DeviceDescriptors')

### DIFF
--- a/bin/browser.js
+++ b/bin/browser.js
@@ -128,7 +128,7 @@ const callChrome = async () => {
         }
 
         if (request.options && request.options.device) {
-            const devices = require('puppeteer/DeviceDescriptors');
+            const devices = puppeteer.devices;
             const device = devices[request.options.device];
             await page.emulate(device);
         }


### PR DESCRIPTION
Puppeteer v5.0.0 has removed the top-level file `puppeteer/DeviceDescriptors` from the Puppeteer package ([#6043](https://github.com/puppeteer/puppeteer/pull/6043)), causing the following error when using the `->device()` option:

`Error: Cannot find module 'puppeteer/DeviceDescriptors'`

The same data is exposed via `puppeteer.devices`, so `bin/browser.js` should be updated accordingly.