### PR TITLE
feat(browser): use pipe instead of WebSocket

### DIFF
--- a/bin/browser.js
+++ b/bin/browser.js
@@ -68,7 +68,8 @@ const callChrome = async () => {
             browser = await puppeteer.launch({
                 ignoreHTTPSErrors: request.options.ignoreHttpsErrors,
                 executablePath: request.options.executablePath,
-                args: request.options.args || []
+                args: request.options.args || [],
+                pipe: true,
             });
         }
 


### PR DESCRIPTION
Hi :wave: 

We are using Browsershot and Puppeteer on AWS Lambda to generate a large amount of PDFs.

It's working fine, but sometimes we face the error:
```txt
The command "PATH=$PATH:/usr/local/bin NODE_PATH=`npm root -g` node '/var/task/vendor/spatie/browsershot/src/../bin/browser.js' '{"url":"file:\/\/\/tmp\/1993981674-0631174001594101615\/index.html","action":"pdf","options":{"args":["--disable-dev-shm-usage","--disable-gpu","--single-process","--no-sandbox"],"viewport":{"width":800,"height":600},"executablePath":"\/tmp\/chromium\/chromium-78.0.3882.0","ignoreHttpsErrors":true,"waitUntil":"domcontentloaded","functionPolling":200,"functionTimeout":20000,"function":"areAllChartsRendered","timeout":60000,"width":"21cm","height":"29.7cm","margin":{"top":"0mm","right":"0mm","bottom":"0mm","left":"0mm"},"displayHeaderFooter":false,"printBackground":true}}'" failed.

Exit Code: 1(General error)

Working directory: /var/task

Output:
================


Error Output:
================
sh: npm: command not found
Error: Protocol error (Page.printToPDF): Target closed.
    at /var/task/node_modules/puppeteer/lib/Connection.js:183:56
    at new Promise (<anonymous>)
    at CDPSession.send (/var/task/node_modules/puppeteer/lib/Connection.js:182:12)
    at Page.pdf (/var/task/node_modules/puppeteer/lib/Page.js:977:39)
    at Page.<anonymous> (/var/task/node_modules/puppeteer/lib/helper.js:112:23)
    at getOutput (/var/task/vendor/spatie/browsershot/bin/browser.js:27:40)
    at callChrome (/var/task/vendor/spatie/browsershot/bin/browser.js:214:24)
    at processTicksAndRejections (internal/process/task_queues.js:93:5) {
  message: 'Protocol error (Page.printToPDF): Target closed.'
}
```

Someone has the issue (https://github.com/puppeteer/puppeteer/issues/2735), and a fix was proposed (https://github.com/puppeteer/puppeteer/issues/2735#issuecomment-470309033) by using `pipe: true` when launching Puppeteer.

Since we can't configure this kind of option from the userland, and I don't wanted to copy/paste the whole `browser.js` file and add this line, I'm opening this PR.

I confirm that I can still generate a PDF with this option.

What do you think? 
Thanks!