### PR TITLE
Replace emulateMedia call with emulateMediaType

### DIFF
--- a/bin/browser.js
+++ b/bin/browser.js
@@ -134,7 +134,7 @@ const callChrome = async () => {
         }
 
         if (request.options && request.options.emulateMedia) {
-            await page.emulateMedia(request.options.emulateMedia);
+            await page.emulateMediaType(request.options.emulateMedia);
         }
 
         if (request.options && request.options.viewport) {


### PR DESCRIPTION
The emulateMedia method was removed in https://github.com/puppeteer/puppeteer/pull/6084 (version 5.0)
emulateMedia was an alias of emulateMediaType