### PR TITLE
Fix link to device list in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Browsershot::url('https://example.com')
 
 #### Device emulation
 
-You can emulate a device view with the `device` method. The devices' names can be found [Here](https://github.com/puppeteer/puppeteer/blob/master/src/DeviceDescriptors.ts).
+You can emulate a device view with the `device` method. The devices' names can be found [Here](https://github.com/puppeteer/puppeteer/blob/main/src/common/DeviceDescriptors.ts).
 
 ```php
 $browsershot = new Browsershot('https://example.com', true);


### PR DESCRIPTION
Change the link to the device list to https://github.com/puppeteer/puppeteer/blob/main/src/common/DeviceDescriptors.ts
