### PR TITLE
local file patch

### DIFF
--- a/bin/browser.js
+++ b/bin/browser.js
@@ -167,11 +167,8 @@ const callChrome = async pup => {
         } else if (request.options && request.options.waitUntil) {
             requestOptions.waitUntil = request.options.waitUntil;
         }
-        /**this isfix for local file access, php creates local temporary file using file scheme protocol. below code validates
-        * the use of file scheme and enforces the usage of page.setContent function
-        * refer https://github.com/puppeteer/puppeteer/blob/v5.4.1/docs/api.md#pagesetcontenthtml-options
-        */
-        if(request.url.trim().toLowerCase().substring(0,4)=='file'){
+
+        if(request.url.trim().toLowerCase().substring(0,4) === 'file'){
             await page.setContent(fs.readFileSync(new URL(request.url),'utf-8'),requestOptions);
         }
         else

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -167,8 +167,17 @@ const callChrome = async pup => {
         } else if (request.options && request.options.waitUntil) {
             requestOptions.waitUntil = request.options.waitUntil;
         }
-
-        await page.goto(request.url, requestOptions);
+        /**this isfix for local file access, php creates local temporary file using file scheme protocol. below code validates
+        * the use of file scheme and enforces the usage of page.setContent function
+        * refer https://github.com/puppeteer/puppeteer/blob/v5.4.1/docs/api.md#pagesetcontenthtml-options
+        */
+        if(request.url.trim().toLowerCase().substring(0,4)=='file'){
+            await page.setContent(fs.readFileSync(new URL(request.url),'utf-8'),requestOptions);
+        }
+        else
+        {
+            await page.goto(request.url, requestOptions);
+        }
 
         if (request.options && request.options.disableImages) {
             await page.evaluate(() => {


### PR DESCRIPTION
This library  is creating temporary files and loading them up with file:/// protocol scheme [https://github.com/spatie/browsershot/blob/4148f910735cf385070cb1a6ff1ac26a37eefd10/src/Browsershot.php#L707](url) when 'Browsershot::html' function is used. Using a file protocol scheme along with headless browser such as Chrome on a server side is not a good idea and will lead to Local file disclosure (Security Vulnerability). Other local files present on the server could be loaded when a malicious HTML is provided. Local files can be loaded either with <iframe> (e.g. <iframe src="file:///etc/passwd" width= height=>) or by setting the different document location. Also, it is unlikely for the developers to check each and every page for malicious JavaScript inputs. This vulnerability can be verified by using below snippet

```
<?php
use Spatie\Browsershot\Browsershot;
require __DIR__ . '/vendor/autoload.php';
Browsershot::html('<iframe src="file:///etc/passwd" width=500 height=300></iframe>')->save('example.pdf');

```

I see it can be fixed either in the PHP code or in the JS code. I believe this small JS snippet can be added at [https://github.com/dr4gonw4ll/browsershot/blob/4148f910735cf385070cb1a6ff1ac26a37eefd10/bin/browser.js#L171](url) to make it secure. Below code can be added to library which validates the file protocol scheme and use the 'page.setContent' puppeteer function which loads in 'about:blank' page and does not cause any harm even if malicious JavaScript inputs are provided.

```
       /**This is a fix for local file access, php creates local temporary file using file scheme protocol. Below code validates
        * the use of file scheme and enforces the usage of page.setContent function
        * refer https://github.com/puppeteer/puppeteer/blob/v5.4.1/docs/api.md#pagesetcontenthtml-options
        */
        if(request.url.trim().toLowerCase().substring(0,4)=='file'){
            await page.setContent(fs.readFileSync(new URL(request.url),'utf-8'),requestOptions);
        }
        else
        {
            await page.goto(request.url, requestOptions);
        }

```
I am not sure about the performance impact this additional code will create. Let me know your comments