### PR TITLE
Adding ability to pass envars to browser instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,7 +789,7 @@ If you want to set custom environment variables which affect the browser instanc
 
 ```php
 Browsershot::url('https://example.com')
-   ->setOption('env.TZ', 'Pacific/Auckland')
+   ->setEnvironmentOption(['TZ' => 'Pacific/Auckland'])
    ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -783,6 +783,17 @@ Browsershot::url('https://example.com')
    ...
 ```
 
+#### Passing environment variables to the browser
+
+If you want to set custom environment variables which affect the browser instance you can use:
+
+```php
+Browsershot::url('https://example.com')
+   ->setOption('env.TZ', 'Pacific/Auckland')
+   ...
+```
+
+
 ## Related packages
 
 * Laravel wrapper: [laravel-browsershot](https://github.com/verumconsilium/laravel-browsershot)

--- a/README.md
+++ b/README.md
@@ -789,7 +789,7 @@ If you want to set custom environment variables which affect the browser instanc
 
 ```php
 Browsershot::url('https://example.com')
-   ->setEnvironmentOption(['TZ' => 'Pacific/Auckland'])
+   ->setEnvironmentOptions(['TZ' => 'Pacific/Auckland'])
    ...
 ```
 

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -70,7 +70,11 @@ const callChrome = async pup => {
                 ignoreHTTPSErrors: request.options.ignoreHttpsErrors,
                 executablePath: request.options.executablePath,
                 args: request.options.args || [],
-                pipe: request.options.pipe || false
+                pipe: request.options.pipe || false,
+                env: {
+                    ...(request.options.env || {}),
+                    ...process.env
+                },
             });
         }
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -670,6 +670,11 @@ class Browsershot
         return $this;
     }
 
+    public function setEnvironmentOptions(array $options = []): self
+    {
+        return $this->setOption('env', $options);
+    }
+
     protected function getOptionArgs(): array
     {
         $args = $this->chromiumArguments;

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1440,4 +1440,30 @@ class BrowsershotTest extends TestCase
         file_put_contents($targetPath, $instance->screenshot());
         $this->assertFileExists($targetPath);
     }
+
+    /** @test */
+    public function it_will_allow_passing_environment_variables()
+    {
+        $instance = Browsershot::url('https://example.com')
+            ->setEnvironmentOptions([
+                'TZ' => 'Pacific/Auckland'
+            ]);
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [],
+                'type' => 'png',
+                'env' => [
+                    'TZ' => 'Pacific/Auckland'
+                ]
+            ],
+        ], $instance->createScreenshotCommand('screenshot.png'));
+    }
 }

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1462,7 +1462,7 @@ class BrowsershotTest extends TestCase
                 'type' => 'png',
                 'env' => [
                     'TZ' => 'Pacific/Auckland',
-                ]
+                ],
             ],
         ], $instance->createScreenshotCommand('screenshot.png'));
     }

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1446,7 +1446,7 @@ class BrowsershotTest extends TestCase
     {
         $instance = Browsershot::url('https://example.com')
             ->setEnvironmentOptions([
-                'TZ' => 'Pacific/Auckland'
+                'TZ' => 'Pacific/Auckland',
             ]);
 
         $this->assertEquals([
@@ -1461,7 +1461,7 @@ class BrowsershotTest extends TestCase
                 'args' => [],
                 'type' => 'png',
                 'env' => [
-                    'TZ' => 'Pacific/Auckland'
+                    'TZ' => 'Pacific/Auckland',
                 ]
             ],
         ], $instance->createScreenshotCommand('screenshot.png'));


### PR DESCRIPTION
This PR modifies `bin/browser.js` to to allow passing arbitrary environment variables to the browser instance when launching.

Users can now use `setOption('env', ['TZ' => 'FOO'])` to set specific environment variables which are visible to the browser.

**Why**
For our specific use case we wanted to set the timezone of the browser to match the user, I'm sure there will be other use-cases for this functionality beyond timezones.

**Tests** 
Appears it's not currently possible to test `browser.js` in this manner, but a test has been added for the php implementation of `setEnvironmentOptions`.


**API Changes**
A new method was added to the Browsershot class 

```php
$instance->setEnvironmentOptions([
    'FOO' => 'BAR',
]);
``` 




