### PR TITLE
Replace waitFor with waitForTimeout as its deprecated

### DIFF
--- a/bin/browser.js
+++ b/bin/browser.js
@@ -219,7 +219,7 @@ const callChrome = async pup => {
         }
 
         if (request.options.delay) {
-            await page.waitFor(request.options.delay);
+            await page.waitForTimeout(request.options.delay);
         }
 
         if (request.options.selector) {


### PR DESCRIPTION
Hi!

When using the delay, the following error will be logged:

```
waitFor is deprecated and will be removed in a future release. See https://github.com/puppeteer/puppeteer/issues/6214 for details and how to migrate your code.
```

Seems like waitFor on the page object was deprecated based on this issue https://github.com/puppeteer/puppeteer/issues/6214.

I replaced it following the recommendation in this comment: https://github.com/puppeteer/puppeteer/issues/6214#issuecomment-717895793

Hope this helps 🤘