### PR TITLE
Use local require for puppeteer

### DIFF
--- a/bin/browser.js
+++ b/bin/browser.js
@@ -1,4 +1,3 @@
-const puppeteer = require('puppeteer');
 const fs = require('fs');
 const URL = require('url').URL;
 const URLParse = require('url').parse;
@@ -42,7 +41,7 @@ const callChrome = async pup => {
     let page;
     let output;
     let remoteInstance;
-	const puppet = (pup || puppeteer);
+	const puppet = (pup || require('puppeteer'));
 
     try {
         if (request.options.remoteInstanceUrl || request.options.browserWSEndpoint ) {
@@ -134,7 +133,7 @@ const callChrome = async pup => {
         }
 
         if (request.options && request.options.device) {
-            const devices = puppeteer.devices;
+            const devices = puppet.devices;
             const device = devices[request.options.device];
             await page.emulate(device);
         }


### PR DESCRIPTION
I am using an approach similar to https://github.com/spatie/browsershot/pull/399#issuecomment-700730688 to run Browsershot on Vapor.

While `callChrome()` being exposed helps out a lot already, it still depends on the `puppeteer` library being installed.
Since `chrome-aws-lambda` uses `puppeteer-core`, browser.js crashes when being executed, even if you pass a custom instance.

This PR moves the actual require call into the function, so it will only be loaded when necessary.
There was also one extra line where the wrong instance was being used.