### PR TITLE
Introduce a selectorIndex to bypass querySelector restrictions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
-You can take a screenshot of an element matching a selector using `select` and an optional `$selectorIndex`.
+You can take a screenshot of an element matching a selector using `select` and an optional `$selectorIndex` which is used to select the nth element (e.g. use `$selectorIndex = 3` to get the forth element like `div:eq(3)`). By default `$selectorIndex` is `0` which represents the first matching element.
 
 ```php
 Browsershot::url('https://example.com')

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
-You can take a screenshot of an element matching a selector using `select` and an optional `$selectorIndex` which is used to select the nth element (e.g. use `$selectorIndex = 3` to get the forth element like `div:eq(3)`). By default `$selectorIndex` is `0` which represents the first matching element.
+You can take a screenshot of an element matching a selector using `select` and an optional `$selectorIndex` which is used to select the nth element (e.g. use `$selectorIndex = 3` to get the fourth element like `div:eq(3)`). By default `$selectorIndex` is `0` which represents the first matching element.
 
 ```php
 Browsershot::url('https://example.com')

--- a/README.md
+++ b/README.md
@@ -227,11 +227,11 @@ Browsershot::url('https://example.com')
     ->save($pathToImage);
 ```
 
-You can take a screenshot of an element matching a selector using `select`.
+You can take a screenshot of an element matching a selector using `select` and an optional `$selectorIndex`.
 
 ```php
 Browsershot::url('https://example.com')
-    ->select('.some-selector')
+    ->select('.some-selector', $selectorIndex)
     ->save($pathToImage);
 ```
 

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -222,12 +222,23 @@ const callChrome = async pup => {
         }
 
         if (request.options.selector) {
-            const element = await page.$$(request.options.selector);
-            if (element[request.options.selectorIndex || 0] === null) {
+        	var element;
+            const index = request.options.selectorIndex || 0;
+            if(index){
+            	element = await page.$$(request.options.selector);
+            	if(!element.length || typeof element[index] === 'undefined'){
+            		element = null;
+            	}else{
+            		element = element[index];
+            	}
+            }else{
+            	element = await page.$(request.options.selector);
+            }
+            if (element === null) {
                 throw {type: 'ElementNotFound'};
             }
 
-            request.options.clip = await element[request.options.selectorIndex || 0].boundingBox();
+            request.options.clip = await element.boundingBox();
         }
 
         if (request.options.function) {

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -222,12 +222,12 @@ const callChrome = async pup => {
         }
 
         if (request.options.selector) {
-            const element = await page.$(request.options.selector);
-            if (element === null) {
+            const element = await page.$$(request.options.selector);
+            if (element[request.options.selectorIndex || 0] === null) {
                 throw {type: 'ElementNotFound'};
             }
 
-            request.options.clip = await element.boundingBox();
+            request.options.clip = await element[request.options.selectorIndex || 0].boundingBox();
         }
 
         if (request.options.function) {

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -239,8 +239,13 @@ class Browsershot
 
     public function select($selector, $index = 0)
     {
-        $this->setOption('selectorIndex', $index);
+        $this->selectorIndex($index);
         return $this->setOption('selector', $selector);
+    }
+
+    public function selectorIndex(int $index)
+    {
+        return $this->setOption('selectorIndex', $index);
     }
 
     public function showBrowserHeaderAndFooter()

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -239,7 +239,8 @@ class Browsershot
 
     public function select($selector, $index = 0)
     {
-        return $this->setOption('selector', $selector) && $this->setOption('selectorIndex', $index);
+        $this->setOption('selectorIndex', $index);
+        return $this->setOption('selector', $selector);
     }
 
     public function showBrowserHeaderAndFooter()

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -237,9 +237,9 @@ class Browsershot
         return $this->setOption('clip', compact('x', 'y', 'width', 'height'));
     }
 
-    public function select($selector)
+    public function select($selector, $index = 0)
     {
-        return $this->setOption('selector', $selector);
+        return $this->setOption('selector', $selector) && $this->setOption('selectorIndex', $index);
     }
 
     public function showBrowserHeaderAndFooter()


### PR DESCRIPTION
I would like to get the screenshot of the nth element on a page but `document.querySelector` cannot handle `eq:(xx)` like

    document.querySelector('body:eq(0)')

The solution would be to use 

    document.querySelectorAll('body')[0]

