### PR TITLE
Bump temporary-directory to version 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "spatie/image": "^1.5.3",
-        "spatie/temporary-directory": "^1.1",
+        "spatie/temporary-directory": "^2.0",
         "symfony/process": "^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
We cannot use Mailcoach together with this package because Mailcoach requires 2.0.

Just like https://github.com/spatie/laravel-sitemap/pull/379 ;)