### PR TITLE
Add base64pdf method

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,12 @@ You can also pass some html which will be converted to a pdf.
 Browsershot::html($someHtml)->savePdf('example.pdf');
 ```
 
+If you need the base64 version of a PDF you can use the `base64pdf` method. This can come in handy when you don't want to save the screenshot on disk in environments like Heroku that don't allow you to save a file. You can then proceed to create the file and upload it directly as a base64 string using a package like [Laravel Media Library](https://spatie.be/docs/laravel-medialibrary/v9/api/adding-files#addmediafrombase64).
+
+```php
+$base64Data = Browsershot::url('https://example.com')
+    ->base64pdf();
+```
 #### Sizing the pdf
 
 You can specify the width and the height.

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -579,6 +579,14 @@ class Browsershot
         }
     }
 
+    public function base64pdf(): string
+    {
+        $command = $this->createPdfCommand();
+
+        return $this->callBrowser($command);
+    }
+
+
     public function evaluate(string $pageFunction): string
     {
         $command = $this->createEvaluateCommand($pageFunction);

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -217,6 +217,15 @@ class BrowsershotTest extends TestCase
     }
 
     /** @test */
+    public function it_can_return_a_pdf_as_base_64()
+    {
+        $base64 = Browsershot::url('https://example.com')
+            ->base64pdf();
+
+        $this->assertTrue(is_string($base64));
+    }
+
+    /** @test */
     public function it_can_handle_a_permissions_error()
     {
         $targetPath = '/cantWriteThisPdf.png';


### PR DESCRIPTION
# Background
This package is platform agnostic, as such, functionality provided by the Laravel framework such as file uploads becomes a tricky issue on environments like Heroku where files can't be created on its ephemeral storage. Therefore, to use this in such an environment proves almost impossible. 

# Solution
This PR introduces a `base64pdf()` method. This method allows for a PDF to be created and returned as a base64 string, just like the `base64Screenshot` method. With the base64string, you can be able to use that to create a file using the laravel Storage facade which will persist it to your disk of choice keeping it in memory. Alternatively, using the Spatie Laravel Media Library, you can directly upload the base64 string to your disk of choice. 

# Example
## Laravel Storage
```php
    $base64_pdf = Browsershot::url('https://example.com')->base64pdf();
    @list($type, $file_data) = explode(';', $base64_pdf );
    @list(, $file_data) = explode(',', $file_data); 
    $img_name= 'cool-file-name.png';   
    Storage::disk('s3')->put($img_name, base64_decode($file_data));
```

## Laravel Media Library
```php
    $base64_pdf = Browsershot::url('https://example.com')
    ->base64pdf();
    $model->addMediaFromBase64($base64_pdf)
          ->usingFileName('cool-pdf-name.pdf')
          ->toMediaCollection();
```