### PR TITLE
Add support for the `--user-data-dir` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,16 @@ $image = Browsershot::url('https://example.com')
     ->screenshot()
 ```
 
+#### Setting the user data directory
+
+You can set the [user data directory](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/user_data_dir.md) that is used to store the browser session and additional data. Setting this to a static value may introduce cache problems, could also increase performance. It needs to be an absolute path.
+
+```php
+$image = Browsershot::url('https://example.com')
+    ->userDataDir('/tmp/session-1')
+    ->screenshot()
+```
+
 ### PDFs
 
 Browsershot will save a pdf if the path passed to the `save` method has a `pdf` extension.

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -459,6 +459,16 @@ class Browsershot
         return $this->setDelay($delayInMilliseconds);
     }
 
+    public function setUserDataDir(string $absolutePath)
+    {
+        return $this->addChromiumArguments(['user-data-dir' => $absolutePath]);
+    }
+
+    public function userDataDir(string $absolutePath)
+    {
+        return $this->setUserDataDir($absolutePath);
+    }
+
     public function writeOptionsToFile()
     {
         $this->writeOptionsToFile = true;

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1353,6 +1353,31 @@ class BrowsershotTest extends TestCase
     }
 
     /** @test */
+    public function it_will_set_user_data_dir_arg_flag()
+    {
+        $dataDir = __DIR__.'/temp/session';
+        $command = Browsershot::url('https://example.com')
+            ->userDataDir($dataDir)
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [
+                    "--user-data-dir={$dataDir}",
+                ],
+                'type' => 'png',
+            ],
+        ], $command);
+    }
+
+    /** @test */
     public function it_will_apply_manipulations_when_taking_screen_shots()
     {
         $screenShot = Browsershot::url('https://example.com')


### PR DESCRIPTION
There are multiple ways to skin this cat, as it is a direct option for the puppeteer [launch options](https://pptr.dev/#?product=Puppeteer&version=v10.2.0&show=api-puppeteerlaunchoptions) as `userDataDir`, but could also just be set with the `args` option. I chose using the `args` option as it seemed less invasive. This theoretically should fix #101.