### PR TITLE
Added functionality to only send headers with navigational requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,16 @@ Browsershot::url('https://example.com')
    ...
 ```
 
+#### Setting extraNavigationHTTPHeaders
+
+To only send custom HTTP headers with navigational http requests, set the extraNavigationHTTPHeaders option like so:
+
+```php
+Browsershot::url('https://example.com')
+    ->setExtraNavigationHttpHeaders(['Custom-Header-Name' => 'Custom-Header-Value'])
+   ...
+```
+
 #### Using HTTP Authentication
 
 You can provide credentials for HTTP authentication:

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -41,7 +41,7 @@ const callChrome = async pup => {
     let page;
     let output;
     let remoteInstance;
-	const puppet = (pup || require('puppeteer'));
+    const puppet = (pup || require('puppeteer'));
 
     try {
         if (request.options.remoteInstanceUrl || request.options.browserWSEndpoint ) {
@@ -163,6 +163,22 @@ const callChrome = async pup => {
             await page.setViewport(request.options.viewport);
         }
 
+        if (request.options && request.options.extraNavigationHTTPHeaders) {
+            page.on('request', request => {
+                // Do nothing in case of non-navigation requests.
+                if (!request.isNavigationRequest()) {
+                    request.continue();
+                    return;
+                }
+                // Add the extra headers for the navigation request.
+                request.continue({ headers: {
+                        ...request.headers(),
+                        ...request.options.extraNavigationHTTPHeaders
+                    } 
+                });
+            });
+        }
+
         if (request.options && request.options.extraHTTPHeaders) {
             await page.setExtraHTTPHeaders(request.options.extraHTTPHeaders);
         }
@@ -239,17 +255,17 @@ const callChrome = async pup => {
         }
 
         if (request.options.selector) {
-        	var element;
+            var element;
             const index = request.options.selectorIndex || 0;
             if(index){
-            	element = await page.$$(request.options.selector);
-            	if(!element.length || typeof element[index] === 'undefined'){
-            		element = null;
-            	}else{
-            		element = element[index];
-            	}
+                element = await page.$$(request.options.selector);
+                if(!element.length || typeof element[index] === 'undefined'){
+                    element = null;
+                }else{
+                    element = element[index];
+                }
             }else{
-            	element = await page.$(request.options.selector);
+                element = await page.$(request.options.selector);
             }
             if (element === null) {
                 throw {type: 'ElementNotFound'};
@@ -298,7 +314,7 @@ const callChrome = async pup => {
 };
 
 if (require.main === module) {
-	callChrome();
+    callChrome();
 }
 
 exports.callChrome = callChrome;

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -151,6 +151,13 @@ class Browsershot
         return $this;
     }
 
+    public function setExtraNavigationHttpHeaders(array $extraNavigationHTTPHeaders)
+    {
+        $this->setOption('extraNavigationHTTPHeaders', $extraNavigationHTTPHeaders);
+
+        return $this;
+    }
+
     public function authenticate(string $username, string $password)
     {
         $this->setOption('authentication', compact('username', 'password'));

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -922,6 +922,29 @@ class BrowsershotTest extends TestCase
     }
 
     /** @test */
+    public function it_can_send_extra_navigation_http_headers()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->setExtraNavigationHttpHeaders(['extra-http-header' => 'extra-http-header'])
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'extraNavigationHTTPHeaders' => ['extra-http-header' => 'extra-http-header'],
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [],
+                'type' => 'png',
+            ],
+        ], $command);
+    }
+
+    /** @test */
     public function it_can_authenticate()
     {
         $command = Browsershot::url('https://example.com')


### PR DESCRIPTION
When opening pages the extra headers are sent with all subsequent request. Not every domain plays well with this strategy.

Domains with `Access-Control-Allow-Headers` will fail in preflight checks. 

I've added the option to set headers which are only send with navigational requests (e.g. the main request).

(i also converted inconsistent indenting in the browser.js file to spaces)