### PR TITLE
Fix blockDomains and blockUrls methods

### DIFF
--- a/bin/browser.js
+++ b/bin/browser.js
@@ -117,18 +117,15 @@ const callChrome = async pup => {
             }
 
             if (request.options && request.options.blockDomains) {
-                const hostname = URLParse(request.url()).hostname;
-                domainsArray.forEach(function(value){
-                    if (hostname.indexOf(value) >= 0) {
-                        interceptedRequest.abort();
-                        return;
-                    }
-                });
+                const hostname = URLParse(interceptedRequest.url()).hostname;
+                if (request.options.blockDomains.includes(hostname)) {
+                    interceptedRequest.abort();
+                    return;
+                }
             }
 
             if (request.options && request.options.blockUrls) {
-                var urlsArray = JSON.parse(request.options.blockUrls);
-                urlsArray.forEach(function(value){
+                request.options.blockUrls.forEach(function(value) {
                     if (interceptedRequest.url().indexOf(value) >= 0) {
                         interceptedRequest.abort();
                         return;

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -387,12 +387,12 @@ class Browsershot
 
     public function blockUrls($array)
     {
-        return $this->setOption('blockUrls', json_encode($array));
+        return $this->setOption('blockUrls', $array);
     }
 
     public function blockDomains($array)
     {
-        return $this->setOption('blockDomains', json_encode($array));
+        return $this->setOption('blockDomains', $array);
     }
 
     public function pages(string $pages)

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -727,6 +727,64 @@ class BrowsershotTest extends TestCase
             ],
         ], $command);
     }
+    
+    /** @test */
+    public function it_can_block_urls()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->blockUrls([
+                'example.com/cm-notify?pi=outbrain',
+                'sync.outbrain.com/cookie-sync?p=bidswitch',
+            ])
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'blockUrls' => [
+                    'example.com/cm-notify?pi=outbrain',
+                    'sync.outbrain.com/cookie-sync?p=bidswitch',
+                ],
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [],
+                'type' => 'png',
+            ],
+        ], $command);
+    }
+
+    /** @test */
+    public function it_can_block_domains()
+    {
+        $command = Browsershot::url('https://example.com')
+            ->blockDomains([
+                'googletagmanager.com',
+                'google-analytics.com',
+            ])
+            ->createScreenshotCommand('screenshot.png');
+
+        $this->assertEquals([
+            'url' => 'https://example.com',
+            'action' => 'screenshot',
+            'options' => [
+                'blockDomains' => [
+                    'googletagmanager.com',
+                    'google-analytics.com',
+                ],
+                'path' => 'screenshot.png',
+                'viewport' => [
+                    'width' => 800,
+                    'height' => 600,
+                ],
+                'args' => [],
+                'type' => 'png',
+            ],
+        ], $command);
+    }
 
     /** @test */
     public function it_can_ignore_https_errors()


### PR DESCRIPTION
I found 3 issues with these methods:
- `Browsershot.php` was encoding the blocked URLs and domains twice: using `json_encode()` within the method itself and then a second time inside `getFullCommand()`. Which would generate this JSON:
```json
"blockDomains":"[\google-analytics.com\,\fonts.googleapis.com\]"
```
and cause this error:
```
SyntaxError: Unexpected token g in JSON at position 418 at JSON.parse
(Invalid escape character in string)
```
instead of generating this JSON:
```json
"blockDomains": ["google-analytics.com", "fonts.googleapis.com"]
```

- `browser.js` was referring to a variable named `domainsArray` which did not exist anymore
- `browser.js` was trying the parse the hostname from the `request` variable instead of the `interceptedRequest` variable

I added some missing tests as well.

Fixes https://github.com/spatie/browsershot/discussions/527