### PR TITLE
Fix Apple Silicon Path Issue

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -17,7 +17,7 @@ class Browsershot
     protected $nodeBinary = null;
     protected $npmBinary = null;
     protected $nodeModulePath = null;
-    protected $includePath = '$PATH:/usr/local/bin';
+    protected $includePath = '$PATH:/usr/local/bin:/opt/homebrew/bin';
     protected $binPath = null;
     protected $html = '';
     protected $noSandbox = false;


### PR DESCRIPTION
If you are running Browsershot on Apple Silicon, you will run into issues with your path. This PR adds the new Homebrew directory to the default path and fixes https://github.com/spatie/browsershot/discussions/580.