### PR TITLE
Adding compatibility to Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^7.4|^8.0",
         "spatie/image": "^1.5.3|^2.0",
         "spatie/temporary-directory": "^1.1|^2.0",
-        "symfony/process": "^4.2|^5.0"
+        "symfony/process": "^4.2|^5.0|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
As mentioned in #588 it seems to work well also with `symfony/process` in version `6.0` and analogue to the proposed change in `spatie/image`.