### PR TITLE
Update Puppeteer GitHub link

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -3,7 +3,7 @@ title: Introduction
 weight: 1
 ---
 
-The package can convert a webpage to an image or pdf. The conversion is done behind the scenes by [Puppeteer](https://github.com/GoogleChrome/puppeteer) which controls a headless version of Google Chrome.
+The package can convert a webpage to an image or pdf. The conversion is done behind the scenes by [Puppeteer](https://github.com/puppeteer/puppeteer) which controls a headless version of Google Chrome.
 
 Here's a quick example:
 


### PR DESCRIPTION
Update the puppeteer GitHub link, because the old link redirected to new GitHub repo of puppeteer