### PR TITLE
Use function arguments for `mobile` and `touch`

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -346,12 +346,12 @@ class Browsershot
 
     public function mobile(bool $mobile = true)
     {
-        return $this->setOption('viewport.isMobile', true);
+        return $this->setOption('viewport.isMobile', $mobile);
     }
 
     public function touch(bool $touch = true)
     {
-        return $this->setOption('viewport.hasTouch', true);
+        return $this->setOption('viewport.hasTouch', $touch);
     }
 
     public function landscape(bool $landscape = true)


### PR DESCRIPTION
Currently function arguments are not being used with `mobile()` and `touch()` function.

This change makes it possible to explicitly set options to `false` by using the function arguments.