### PR TITLE
Update savePdf to comply with 50eae92

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -593,12 +593,12 @@ class Browsershot
     {
         $command = $this->createPdfCommand($targetPath);
 
-        $this->callBrowser($command);
+        $output = $this->callBrowser($command);
 
         $this->cleanupTemporaryHtmlFile();
 
         if (! file_exists($targetPath)) {
-            throw CouldNotTakeBrowsershot::chromeOutputEmpty($targetPath);
+            throw CouldNotTakeBrowsershot::chromeOutputEmpty($targetPath, $output);
         }
     }
 


### PR DESCRIPTION
The call to `CouldNotTakeBrowsershot::chromeOutputEmpty()` now requires a second argument, since 50eae92