### PR TITLE
Fixed issue Error: Request is already handled! in NodeJs v17.8.0

### DIFF
--- a/bin/browser.js
+++ b/bin/browser.js
@@ -127,7 +127,6 @@ const callChrome = async pup => {
             if (request.options && request.options.blockUrls) {
                 for (const element of request.options.blockUrls) {
                     if (interceptedRequest.url().indexOf(element) >= 0) {
-                        console.log("URL " + interceptedRequest.url() + " blocked by blockUrls");
                         interceptedRequest.abort();
                         return;
                     }

--- a/bin/browser.js
+++ b/bin/browser.js
@@ -125,12 +125,13 @@ const callChrome = async pup => {
             }
 
             if (request.options && request.options.blockUrls) {
-                request.options.blockUrls.forEach(function(value) {
-                    if (interceptedRequest.url().indexOf(value) >= 0) {
+                for (const element of request.options.blockUrls) {
+                    if (interceptedRequest.url().indexOf(element) >= 0) {
+                        console.log("URL " + interceptedRequest.url() + " blocked by blockUrls");
                         interceptedRequest.abort();
                         return;
                     }
-                });
+                }
             }
 
             if (request.options && request.options.extraNavigationHTTPHeaders) {


### PR DESCRIPTION
Fixes this error that happens when using blockUrls() with NodeJs v17.8.0:

```
Exit Code: 1(General error)

Working directory: /root/browsershot

Output:
================


Error Output:
================
/root/node_modules/puppeteer/lib/cjs/puppeteer/common/assert.js:26
        throw new Error(message);
              ^

Error: Request is already handled!
    at assert (/root/node_modules/puppeteer/lib/cjs/puppeteer/common/assert.js:26:15)
    at HTTPRequest.continue (/root/node_modules/puppeteer/lib/cjs/puppeteer/common/HTTPRequest.js:304:32)
    at /root/browsershot/vendor/spatie/browsershot/bin/browser.js:143:40
    at /root/node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:219:52
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async HTTPRequest.finalizeInterceptions (/root/node_modules/puppeteer/lib/cjs/puppeteer/common/HTTPRequest.js:151:9)

Node.js v17.8.0
 in /root/browsershot/vendor/spatie/browsershot/src/Browsershot.php:824
Stack trace:
#0 /root/browsershot/vendor/spatie/browsershot/src/Browsershot.php(533): Spatie\Browsershot\Browsershot->callBrowser()
#1 /root/browsershot/test.php(45): Spatie\Browsershot\Browsershot->save()
#2 {main}
  thrown in /root/browsershot/vendor/spatie/browsershot/src/Browsershot.php on line 824

```

After thix fix on browser.js it works fine:

```
root@server:~/browsershot# php -f test.php https://www.google.com
Screenshot created successfully!
```

