### PR TITLE
Added method setContentUrl to set url when using html method

### DIFF
--- a/docs/miscellaneous-options/using-url-for-html-content.md
+++ b/docs/miscellaneous-options/using-url-for-html-content.md
@@ -1,0 +1,12 @@
+---
+title: Using url for html content
+weight: 21
+---
+
+Using the method *setContentUrl* you can set the base url of the request when using the *html* method. Sometimes you may have relative paths in your code. When passing a html page to puppeteer, you don't have a base url set. So any relative path present in your html content will not fetch correctly.
+
+```php
+Browsershot::html('<html>... relative paths to fetch ...</html>')
+   ->setContentUrl('https://www.example.com')
+   ...
+```

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -745,6 +745,11 @@ class Browsershot
         return $this->setOption('env', $options);
     }
 
+    public function setContentUrl(string $contentUrl): self
+    {
+        return $this->html ? $this->setOption('contentUrl', $contentUrl) : $this;
+    }
+
     protected function getOptionArgs(): array
     {
         $args = $this->chromiumArguments;

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1481,3 +1481,30 @@ it('can throw an error when response is unsuccessful', function () {
 
     $this->assertFileDoesNotExist($targetPath);
 });
+
+it('will allow passing a content url', function () {
+    $instance = Browsershot::html('<h1>Hello world!!</h1>')
+        ->setContentUrl('https://example.com');
+
+    $response = $instance->createScreenshotCommand('screenshot.png');
+
+    $responseUrl = $response['url'];
+    unset($response['url']);
+
+    $this->assertEquals([
+        'action' => 'screenshot',
+        'options' => [
+            'path' => 'screenshot.png',
+            'viewport' => [
+                'width' => 800,
+                'height' => 600,
+            ],
+            'args' => [],
+            'type' => 'png',
+            'displayHeaderFooter' => false,
+            'contentUrl' => 'https://example.com',
+        ],
+    ], $response);
+
+    $this->assertStringContainsString("file://", $responseUrl);
+});


### PR DESCRIPTION
This pull request adds a new method called setContentUrl.

When using the method html, sometimes you may have relative paths in your code, that needs a base url to be completely fetched. This feature allows setting this url into puppeteer.