### PR TITLE
Add an Option to inject pagedjs polyfill

### DIFF
--- a/bin/browser.js
+++ b/bin/browser.js
@@ -298,6 +298,11 @@ const callChrome = async pup => {
         }
 
         if (request.options && request.options.pagedjs) {
+            await page.evaluate(() => {
+                window.PagedConfig = window.PagedConfig || {};
+                window.PagedConfig.auto = false;
+            });
+            
             await page.addScriptTag({
 				url: request.options.pagedjs
 			});

--- a/docs/miscellaneous-options/use-with-pagedjs.md
+++ b/docs/miscellaneous-options/use-with-pagedjs.md
@@ -1,0 +1,18 @@
+---
+title: Use paged.js 
+weight: 21
+---
+
+You can inject the paged.js polyfill library:
+
+```php
+Browsershot::url('https://example.com')
+    ->usePagedJS()
+```
+
+You can also provide a custom version of the script which will be injected as an argument:
+
+```php
+Browsershot::url('https://example.com')
+    ->usePagedJS('https://unpkg.com/pagedjs@0.2.0/dist/paged.polyfill.js')
+```

--- a/docs/miscellaneous-options/using-a-pipe-instead-of-a-websocket.md
+++ b/docs/miscellaneous-options/using-a-pipe-instead-of-a-websocket.md
@@ -1,6 +1,6 @@
 ---
 title: Using a pipe instead of a WebSocket
-weight: 21
+weight: 22
 ---
 
 If you want to connect to the browser over a pipe instead of a WebSocket, you can use:

--- a/docs/miscellaneous-options/using-cookies.md
+++ b/docs/miscellaneous-options/using-cookies.md
@@ -1,6 +1,6 @@
 ---
 title: Using cookies
-weight: 22
+weight: 23
 ---
 
 You can add cookies to the request to the given url:

--- a/docs/miscellaneous-options/using-http-authentication.md
+++ b/docs/miscellaneous-options/using-http-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: Using HTTP Authentication
-weight: 23
+weight: 24
 ---
 
 You can provide credentials for HTTP authentication:

--- a/docs/miscellaneous-options/using-url-for-html-content.md
+++ b/docs/miscellaneous-options/using-url-for-html-content.md
@@ -1,6 +1,6 @@
 ---
 title: Using url for html content
-weight: 24
+weight: 25
 ---
 
 Using the method *setContentUrl* you can set the base url of the request when using the *html* method. Sometimes you may have relative paths in your code. When passing a html page to puppeteer, you don't have a base url set. So any relative path present in your html content will not fetch correctly.

--- a/docs/miscellaneous-options/writing-options-to-a-file.md
+++ b/docs/miscellaneous-options/writing-options-to-a-file.md
@@ -1,6 +1,6 @@
 ---
 title: Writing options to a file
-weight: 25
+weight: 26
 ---
 
 When the amount of options given to puppeteer becomes too big, Browsershot will fail because of an overflow of characters in the command line.

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -632,6 +632,10 @@ class Browsershot
         return $this->callBrowser($command);
     }
 
+    public function usePagedJS(string $url = '//unpkg.com/pagedjs/dist/paged.polyfill.js') {
+        $this->setOption('pagedjs', $url);
+    }
+
     public function triggeredRequests(): array
     {
         $command = $this->createTriggeredRequestsListCommand();

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1034,6 +1034,27 @@ it('can evaluate page', function () {
     expect($result)->toEqual('2');
 });
 
+it('can use pagedjs', function () {
+    $command = Browsershot::url('https://example.com')
+        ->usePagedJS()
+        ->createScreenshotCommand('screenshot.png');
+
+    $this->assertEquals([
+        'url' => 'https://example.com',
+        'action' => 'screenshot',
+        'options' => [
+            'pagedjs' => '//unpkg.com/pagedjs/dist/paged.polyfill.js',
+            'path' => 'screenshot.png',
+            'viewport' => [
+                'width' => 800,
+                'height' => 600,
+            ],
+            'args' => [],
+            'type' => 'png',
+        ],
+    ], $command);
+});
+
 it('can add a timeout to puppeteer', function () {
     $command = Browsershot::url('https://example.com')
         ->timeout(123)


### PR DESCRIPTION
While paged.js works well when it's directly included in the head tag of the Site when it's added via script injection (`$browser->setOption('addScriptTag', '{"url": "https://unpkg.com/pagedjs/dist/paged.polyfill.js"}')`) there need to be done some evaluation a wait for a specific selector is added.

Im not sure about the option setter, it might be better to support the json syntax from above so one could include a local `path` version of pagedjs as well. For our case using the remote one is fine, but i could change that if you'd prefer the other variant :)