### PR TITLE
Prevent double request interception on POST

### DIFF
--- a/bin/browser.js
+++ b/bin/browser.js
@@ -101,23 +101,6 @@ const callChrome = async pup => {
 
         await page.setRequestInterception(true);
 
-        if (request.postParams) {
-            const postParamsArray = request.postParams;
-            const queryString = Object.keys(postParamsArray)
-                .map(key => `${key}=${postParamsArray[key]}`)
-                .join('&');
-            page.once("request", interceptedRequest => {
-                interceptedRequest.continue({
-                    method: "POST",
-                    postData: queryString,
-                    headers: {
-                        ...interceptedRequest.headers(),
-                        "Content-Type": "application/x-www-form-urlencoded"
-                    }
-                });
-            });
-        }
-
         const contentUrl = request.options.contentUrl;
         const parsedContentUrl = contentUrl ? contentUrl.replace(/\/$/, "") : undefined;
         let pageContent;
@@ -193,6 +176,22 @@ const callChrome = async pup => {
                     });
                     return;
                 }
+            }
+
+            if (request.postParams) {
+                const postParamsArray = request.postParams;
+                const queryString = Object.keys(postParamsArray)
+                    .map(key => `${key}=${postParamsArray[key]}`)
+                    .join('&');
+                interceptedRequest.continue({
+                    method: "POST",
+                    postData: queryString,
+                    headers: {
+                        ...interceptedRequest.headers(),
+                        "Content-Type": "application/x-www-form-urlencoded"
+                    }
+                });
+                return;
             }
 
             interceptedRequest.continue({ headers });

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -980,6 +980,14 @@ it('can send post request', function () {
     ], $command);
 });
 
+it('can process post request', function () {
+    $html = Browsershot::url('https://httpbin.org/post')
+        ->post(['foo' => 'bar'])
+        ->bodyHtml();
+
+    expect($html)->toContain('"foo": "bar"');
+});
+
 it('can click on the page', function () {
     $command = Browsershot::url('https://example.com')
         ->click('#selector1')


### PR DESCRIPTION
When submitting a post request through Browsershot you get the following error:

```
Error: Request is already handled!
    at assert (browsershot/node_modules/puppeteer/lib/cjs/puppeteer/common/assert.js:28:15)
    at HTTPRequest.continue (browsershot/node_modules/puppeteer/lib/cjs/puppeteer/common/HTTPRequest.js:349:32)
    at browsershot/bin/browser.js:198:40
    at browsershot/node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:275:32
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async HTTPRequest.finalizeInterceptions (browsershot/node_modules/puppeteer/lib/cjs/puppeteer/common/HTTPRequest.js:188:9)
```

This is caused by intercepting the request twice in the browser.js script.

I've added a test that performs a real post which fails on the existing code and works after the change.