### PR TITLE
Security fix: Patch local file read bypass through untrusted js imports

### DIFF
--- a/src/Exceptions/JSLinkIsNotInAllowList.php
+++ b/src/Exceptions/JSLinkIsNotInAllowList.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Browsershot\Exceptions;
+
+use Exception;
+
+class JSLinkIsNotInAllowList extends Exception
+{
+    public static function make(string $jsLink)
+    {
+        return new static("The URL '" . $jsLink . "' is not in the allowList.");
+    }
+}


### PR DESCRIPTION
Hi Freek !

In this patch, the user can define secure URL's in a whitelist. This will prevent an attacker from embedding malicious JS from arbitrary domains.

![security-fix.mp4](https://user-images.githubusercontent.com/51862990/198904914-971785be-795b-4cd2-95e0-9b97467ef4e1.mp4)

Regards.