### PR TITLE
escapeshellcmd can be problematic in paths with spaces on Windows

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -912,7 +912,7 @@ class Browsershot
                 .$optionsCommand
                 .'"';
 
-            return escapeshellcmd($fullCommand);
+            return preg_replace('`(?<!^) `', '^ ', escapeshellcmd($fullCommand));
         }
 
         $setIncludePathCommand = "PATH={$this->includePath}";


### PR DESCRIPTION
## Issue:

On windows paths with spaces like `C:\Program Files\ProgramName\program.exe` can cause issues, this is documented in the PHP docs: https://www.php.net/manual/en/function.escapeshellcmd.php

![image](https://user-images.githubusercontent.com/11036342/200084490-ddd726fa-3304-4f2a-8b3a-e3ca62ac6f77.png)


They recommend adding this code snippet.

```
preg_replace('`(?<!^) `', '^ ', escapeshellcmd($cmd));
```