### PR TITLE
Allow user to explicitly use a local file for html content.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ You can also use an arbitrary html input, simply replace the `url` method with `
 Browsershot::html('<h1>Hello world!!</h1>')->save('example.pdf');
 ```
 
+If your HTML input is already in a file locally use the :
+
+```php
+Browsershot::htmlFromFilePath('/local/path/to/file.html')->save('example.pdf');
+```
+
 Browsershot also can get the body of an html page after JavaScript has been executed:
 
 ```php

--- a/src/Exceptions/FileDoesNotExistException.php
+++ b/src/Exceptions/FileDoesNotExistException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Browsershot\Exceptions;
+
+use Exception;
+
+class FileDoesNotExistException extends Exception
+{
+    public function __construct($file)
+    {
+        parent::__construct("The file `{$file} does not exist");
+    }
+}

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1555,3 +1555,22 @@ it('can set the custom temp path', function () {
 
     expect('application/pdf')->toEqual($mimeType);
 });
+
+
+it('can set html contents from a file', function () {
+    $inputFile = __DIR__.'/temp/test.html';
+    $inputHtml = '<html><head></head><body><h1>Hello World</h1></body></html>';
+
+    file_put_contents($inputFile, $inputHtml);
+
+
+    $outputHtml = Browsershot::htmlFromFilePath($inputFile)
+        ->usePipe()
+        ->bodyHtml();
+
+    expect($outputHtml)->toEqual($inputHtml);
+});
+
+it('can not set html contents from a non-existent file', function () {
+    Browsershot::htmlFromFilePath(__DIR__.'/temp/non-existent-file.html');
+})->throws(\Spatie\Browsershot\Exceptions\FileDoesNotExistException::class);


### PR DESCRIPTION
Sometimes it is necessary to have all the html contents in a local file rather than on a url or in a PHP string due to memory limits. The introduced function `htmlFromFilePath` makes it clear you are intending to set the html from a local file, and there for if the input is not being generated by the user themselves, they should validate the file path is allowed before allowing it to be used.

With 92cf16fc098211731f80d21687abeafbe2c457ad I assume this functionality was removed out of safety concerns.  However, for multiple projects we need to generate the PDF from HTML that is stored in a file that we incrementally build as some of HTML can larger than we want to store in memory. By having the explicit `htmlFromFilePath` it should be clear that a local file is going to be included, so the user should validate the path if they aren't providing it themselves.

I've added tests that verify the local file works and one that makes sure the file exists.