### PR TITLE
Add PHP 8.2 Tests Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,14 +9,14 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.1, 8.0, 7.4]
+                php: [8.2, 8.1, 8.0, 7.4]
                 stability: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2


### PR DESCRIPTION
This PR adds PHP 8.2 support to the GitHub tests workflow, as well as upgrades the `actions/checkout` action to latest version (v3).