### PR TITLE
Node & NPM Permission Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `Browsershot` will be documented in this file
 
+### 2.4.2 - 2017-12-24
+- update dep on `spatie/image`
+
 ### 2.4.1 - 2017-09-27
 - add the default path for linux Chromium users
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "spatie/image": "~1.3.0",
+        "spatie/image": "^1.4",
         "spatie/phpunit-snapshot-assertions": "^1.0",
         "spatie/temporary-directory": "^1.1",
         "symfony/process": "^3.0"


### PR DESCRIPTION
Hi,

I was looking to get some insight on why Browsershot is struggling to use node and npm.

To give you a bit of background, the machine is running Ubuntu 22.04, with Laravel , InertiaJS and VueJS. The machine is on a corporate network so we as installed by a root account and we were given a "sudo" account.

We install node with NVM from the "sudo" account and up to this point we haven't had any issues with node or npm.

The error I'm getting is as below.
`The command "PATH=$PATH:/usr/local/bin:/opt/homebrew/bin NODE_PATH=/home/infosec/.nvm/versions/node/v16.17.1/bin/node /home/infosec/.nvm/versions/node/v16.17.1/bin/npm root -g /home/infosec/.nvm/versions/node/v16.17.1/bin/node '/var/www/CSAPortal_Production/vendor/spatie/browsershot/src/../bin/browser.js' '{"url":"file:\/\/\/tmp\/568908599-0033634001671026490\/index.html","action":"pdf","options":{"path":"test.pdf","args":[],"viewport":{"width":800,"height":600},"displayHeaderFooter":false}}'" failed. Exit Code: 126(Invoked command cannot execute) Working directory: /var/www/CSAPortal_Production/public Output: ================ Error Output: ================ sh: 1: /home/infosec/.nvm/versions/node/v16.17.1/bin/node: Permission denied sh: 1: /home/infosec/.nvm/versions/node/v16.17.1/bin/node: Permission denied`

I had to manually set the node binary and npm binary as Browsershot wasn't picking them up automatically.
`$html = view('pdf.report')->render();

        Browsershot::html($html)->setNodeBinary('/home/infosec/.nvm/versions/node/v16.17.1/bin/node')->setNpmBinary('/home/infosec/.nvm/versions/node/v16.17.1/bin/npm')->save('test.pdf');`
        
Any help would be appreciated.

Thanks,
Nathan