### PR TITLE
Docs: Use setEnvironmentOptions to set Browser Language

### DIFF
--- a/docs/miscellaneous-options/changing-the-language-of-the-browser.md
+++ b/docs/miscellaneous-options/changing-the-language-of-the-browser.md
@@ -3,11 +3,13 @@ title: Changing the language of the browser
 weight: 3
 ---
 
-You can use `setOption` to change the language of the browser.
+You can use `setEnvironmentOptions` to change the language of the browser.
 In order to load a page in a specific language for example.
 
 ```php
 Browsershot::url('https://example.com')
-   ->setOption('args', '--lang=en-GB')
+   ->setEnvironmentOptions([
+      'LANG' => 'en-GB',
+   ])
    ...
 ```


### PR DESCRIPTION
It seems that a recent Chromium update broke setting the language through `setOption()` with `args`. 
(A user of mine mentioned that their custom language setting was no longer working as expected).

Apparently the proper way to set the language of the browser is to use a `LANG`-environment variable.

## Related Links

- https://bugs.chromium.org/p/chromium/issues/detail?id=755338#c14
- https://github.com/puppeteer/puppeteer/issues/1871#issuecomment-365012490
- https://github.com/puppeteer/puppeteer/issues/5970#issuecomment-690677674