### PR TITLE
Fix link to Puppeteer devices in creating-images.md

### DIFF
--- a/docs/usage/creating-images.md
+++ b/docs/usage/creating-images.md
@@ -112,7 +112,7 @@ Browsershot::url('https://example.com')
 
 ## Device emulation
 
-You can emulate a device view with the `device` method. The devices' names can be found [Here](https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/common/Device.ts).
+You can emulate a device view with the `device` method. The devices' names can be found [Here](https://github.com/puppeteer/puppeteer/blob/main/docs/api/puppeteer.knowndevices.md).
 
 ```php
 $browsershot = new Browsershot('https://example.com', true);


### PR DESCRIPTION
Link to Puppeteer devices list is broken. Puppeteer repo structure has changes and removed Devices description that was previously linked. Updated link.