### PR TITLE
Add waitForSelector()

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -369,6 +369,10 @@ const callChrome = async pup => {
             await page.waitForFunction(request.options.function, functionOptions);
         }
 
+        if (request.options.waitForSelector) {
+            await page.waitForSelector(request.options.waitForSelector, request.options.waitForSelectorOptions ?? undefined);
+        }
+
         output = await getOutput(page, request);
 
         if (!request.options.path) {

--- a/docs/usage/creating-images.md
+++ b/docs/usage/creating-images.md
@@ -230,6 +230,17 @@ Browsershot::url('https://example.com')
     ->waitForFunction('window.innerWidth < 100', $pollingInMilliseconds, $timeoutInMilliseconds)
     ->save($pathToImage);
 ```
+
+## Waiting for a selector
+
+You can also wait for a selector by using `waitForSelector()`. This is useful if you need to wait for the selector to appear in page.
+
+```php
+Browsershot::url('https://example.com')
+    ->waitForSelector('#my_selector')
+    ->save($pathToImage);
+```
+
 ## Adding JS
 
 You can add javascript prior to your screenshot or output using the syntax for [Puppeteer's addScriptTag](https://github.com/puppeteer/puppeteer/blob/v1.9.0/docs/api.md#pageaddscripttagoptions).

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -231,6 +231,17 @@ class Browsershot
         return $this->setOption('function', $function);
     }
 
+    public function waitForSelector(string $selector, array $options = [])
+    {
+        $this->setOption('waitForSelector', $selector);
+
+        if (! empty($options)) {
+            $this->setOption('waitForSelectorOptions', $options);
+        }
+
+        return $this;
+    }
+
     public function setUrl(string $url)
     {
         if (Helpers::stringStartsWith(strtolower($url), 'file://')) {

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1127,6 +1127,49 @@ it('can add a wait for function to puppeteer', function () {
     ], $command);
 });
 
+it('can add a wait for selector', function () {
+    $command = Browsershot::url('https://example.com')
+        ->waitForSelector('.wait_for_me')
+        ->createScreenshotCommand('screenshot.png');
+
+    $this->assertEquals([
+        'url' => 'https://example.com',
+        'action' => 'screenshot',
+        'options' => [
+            'waitForSelector' => '.wait_for_me',
+            'path' => 'screenshot.png',
+            'viewport' => [
+                'width' => 800,
+                'height' => 600,
+            ],
+            'args' => [],
+            'type' => 'png',
+        ],
+    ], $command);
+});
+
+it('can add a wait for selector and provide options', function () {
+    $command = Browsershot::url('https://example.com')
+        ->waitForSelector('.wait_for_me', ['visibile' => true])
+        ->createScreenshotCommand('screenshot.png');
+
+    $this->assertEquals([
+        'url' => 'https://example.com',
+        'action' => 'screenshot',
+        'options' => [
+            'waitForSelector' => '.wait_for_me',
+            'waitForSelectorOptions' => ['visibile' => true],
+            'path' => 'screenshot.png',
+            'viewport' => [
+                'width' => 800,
+                'height' => 600,
+            ],
+            'args' => [],
+            'type' => 'png',
+        ],
+    ], $command);
+});
+
 it('can input form fields and post and get the body html', function () {
     $delay = 2000;
 


### PR DESCRIPTION
This PR adds waitForSelector()

This puppeteer functions allows to wait for a selector to be visible in the page before printing.

This has two main use cases.

1- Wait for some content to be loaded via ajax, when that content is loaded a selector will be visible. Only then print the page

2- This can be used as an improvement to the performance.
Instead for waiting for networkidle0 or networkidle2, we can wait for a selector, once that selector is visible the print will start.
This way we don't need to wait for the connections to be closed when using networkidle0 or networkidle2

This function accepts two parameters

1- Selector which is required
2- WaitForSelectorOptions which is optional (For more info please check link below)

Puppeteer docs page for waitForSelector(): https://pptr.dev/api/puppeteer.page.waitforselector

I also added tests and updated the docs