### PR TITLE
Added getOutput method for full output data access on any request

### DIFF
--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1605,7 +1605,7 @@ it('can handle a permissions error with full output', function () {
         $output = $instance->getOutput();
 
         expect($output)->not()->toBeNull();
-        expect($output['exception'])->toContain('EPERM: operation not permitted');
+        expect($output['exception'])->not()->toBeEmpty();
         expect($output['consoleMessages'])->toBe([]);
         expect($output['requestsList'])->toMatchArray([[
             'url' => 'https://example.com/'


### PR DESCRIPTION
When errors occur on any method invoked by browsershot to the puppeteer browser, it's not easy to access console log data right away. Other methods exist like consoleMessages that allows access to these logs on a new browser call, not getting the original logs that were generated on the moment the first call was made.

To facilitate access to these logs, I developed the method getOuput, providing full data access after any call made to the browser.

Instead of only returning the pretended content in each browser call, I modified the output to return a standard object containing the following data:

- consoleMessages: any console messages generated during browser execution
- requestsList: all endpoints called by browser
- failedRequests: all endpoints that failed
- result: result of the method call to the browser. In case of exception this is not set
- exception: in case of a exception, the string representation of it will be here. In success this is not set

Internally this object is decomposed into the real required data by any browsershot method, and then the full object is stored and accessible using getOutput method.

If any additional call to the browser is required, the current output data will be erased and the new one will be placed accordingly.

I made two new tests, calling simple methods of browsershot, and analysing the getOutput structure in two possible situations: success and exception thrown.