### PR TITLE
Update creating-images.md

### DIFF
--- a/docs/usage/creating-images.md
+++ b/docs/usage/creating-images.md
@@ -11,7 +11,7 @@ Browsershot::url('https://example.com')->save($pathToImage);
 
 ## Formatting the image
 
-By default, the screenshot's type will be a `png`. (According to [Puppeteer's Config](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagescreenshotoptions))
+By default, the screenshot's type will be a `png`. (According to [Puppeteer's Config](https://github.com/puppeteer/puppeteer/blob/main/docs/api/puppeteer.screenshotoptions.md))
 But you can change it to `jpeg` with quality option.
 
 ```php
@@ -232,7 +232,7 @@ Browsershot::url('https://example.com')
 ```
 ## Adding JS
 
-You can add javascript prior to your screenshot or output using the syntax for [Puppeteer's addScriptTag](https://github.com/GoogleChrome/puppeteer/blob/v1.9.0/docs/api.md#pageaddscripttagoptions).
+You can add javascript prior to your screenshot or output using the syntax for [Puppeteer's addScriptTag](https://github.com/puppeteer/puppeteer/blob/v1.9.0/docs/api.md#pageaddscripttagoptions).
 
 ```php
 Browsershot::url('https://example.com')
@@ -242,7 +242,7 @@ Browsershot::url('https://example.com')
 
 ## Adding CSS
 
-You can add CSS styles prior to your screenshot or output using the syntax for [Puppeteer's addStyleTag](https://github.com/GoogleChrome/puppeteer/blob/v1.9.0/docs/api.md#pageaddstyletagoptions).
+You can add CSS styles prior to your screenshot or output using the syntax for [Puppeteer's addStyleTag](https://github.com/puppeteer/puppeteer/blob/v1.9.0/docs/api.md#pageaddstyletagoptions).
 
 ```php
 Browsershot::url('https://example.com')


### PR DESCRIPTION
- update broken link

<img width="1678" alt="image" src="https://github.com/spatie/browsershot/assets/37553901/aa2b9d28-ecd6-4cba-a22c-2064b1243db5">



- use original link instead of redirect link

Old link using `GoogleChrome` organization, and when we click they will redirect to `puppeteer` organization. So it's more better we used the new link using `puppeteer` organization than waiting to redirect to there.
