### PR TITLE
Read redirect history

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -16,6 +16,8 @@ const request = args[0].startsWith('-f ')
 
 const requestsList = [];
 
+const redirectHistory = [];
+
 const consoleMessages = [];
 
 const failedRequests = [];
@@ -25,6 +27,12 @@ const getOutput = async (page, request) => {
 
     if (request.action == 'requestsList') {
         output = JSON.stringify(requestsList);
+
+        return output;
+    }
+
+    if (request.action == 'redirectHistory') {
+        output = JSON.stringify(redirectHistory);
 
         return output;
     }
@@ -118,6 +126,15 @@ const callChrome = async pup => {
         }));
 
         page.on('response', function (response) {
+            if (response.request().isNavigationRequest() && response.request().frame().parentFrame() === null) {
+                redirectHistory.push({
+                    url: response.request().url(),
+                    status: response.status(),
+                    reason: response.statusText(),
+                    headers: response.headers()
+                })
+            }
+
             if (response.status() >= 200 && response.status() <= 399) {
                 return;
             }

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -667,6 +667,13 @@ class Browsershot
         return json_decode($this->callBrowser($command), true);
     }
 
+    public function redirectHistory(): array
+    {
+        $command = $this->createRedirectHistoryCommand();
+
+        return json_decode($this->callBrowser($command), true);
+    }
+
     /**
      * @return array{type: string, message: string, location:array}
      */
@@ -767,6 +774,15 @@ class Browsershot
             : $this->url;
 
         return $this->createCommand($url, 'requestsList');
+    }
+
+    public function createRedirectHistoryCommand(): array
+    {
+        $url = $this->html
+            ? $this->createTemporaryHtmlFile()
+            : $this->url;
+
+        return $this->createCommand($url, 'redirectHistory');
     }
 
     public function createConsoleMessagesCommand(): array

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -40,6 +40,33 @@ it('can get the requests list', function () {
     );
 });
 
+it('can get the redirect history', function () {
+    $list = Browsershot::url('http://www.spatie.be')
+        ->redirectHistory();
+
+    $list = array_map(function($item) {unset($item['headers']); return $item;}, $list);
+
+    expect($list)->toHaveCount(3);
+
+    $this->assertEquals([
+        [
+            'url' => 'http://www.spatie.be/',
+            'status' => 301,
+            'reason' => 'Moved Permanently'
+        ],
+        [
+            'url' => 'https://www.spatie.be/',
+            'status' => 301,
+            'reason' => ''
+        ],
+        [
+            'url' => 'https://spatie.be/',
+            'status' => 200,
+            'reason' => ''
+        ],
+    ], $list);
+});
+
 it('will not allow a file url', function () {
     Browsershot::url('file://test');
 })->throws(FileUrlNotAllowed::class);


### PR DESCRIPTION
Sometimes it can happen that the screenshot made by Browsershot is different from the one displayed by your browser.
It is often due to one or more redirects made by the site, based on geolocation, cookies, etc...

To understand what happens, I tried to keep track of the redirects made by the site, both HTTP, Javascript and HTML ones, not using only the Puppeteer redirectChain because it only considers the HTTP ones.
I tried to capture any request that is a navigation requests that attempts to load a new document, mke sure the redirect is in the parent frame or we will see the navigation for other frames.

Since they are available, in addition to the URLs I thought of including HTTP status, reason and headers.