### PR TITLE
Update requirements.md for Forge provisioning

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -21,12 +21,12 @@ npm install puppeteer --location=global
 
 ### Installing puppeteer on a Forge provisioned server
 
-On a [Forge](https://forge.laravel.com) provisioned Ubuntu 20.04 server you can install the latest stable version of Chrome like this:
+On a [Forge](https://forge.laravel.com) provisioned Ubuntu server you can install the latest stable version of Chrome like this:
 
 ```bash
 curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 sudo apt-get install -y nodejs gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libgbm-dev libxshmfence-dev
-sudo npm install --location=global --unsafe-perm puppeteer
+sudo npm install --location=global --unsafe-perm puppeteer@^17
 sudo chmod -R o+rx /usr/lib/node_modules/puppeteer/.local-chromium
 ```
 


### PR DESCRIPTION
The latest versions of Puppeteer do not play nicely on Forge. Constraining to v17 works however. #681 refers