### PR TITLE
Null coalescent operator breaks browserhot in Node < 14

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -379,7 +379,7 @@ const callChrome = async pup => {
         }
 
         if (request.options.waitForSelector) {
-            await page.waitForSelector(request.options.waitForSelector, request.options.waitForSelectorOptions ?? undefined);
+            await page.waitForSelector(request.options.waitForSelector, request.options.waitForSelectorOptions ? request.options.waitForSelectorOptions : undefined);
         }
         
         console.log(await getOutput(request, page));


### PR DESCRIPTION
We updated our Browsershot on a production server which is running a node version older than 14. This resulted in a breaking change for us.

Refactored the null coalescent operator with a ternary if operator. This restores functionality in node < 14 versions.