### PR TITLE
Add firefox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![run-tests](https://img.shields.io/github/actions/workflow/status/spatie/browsershot/run-tests.yml?label=tests&style=flat-square)](https://github.com/spatie/browsershot/actions)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/browsershot.svg?style=flat-square)](https://packagist.org/packages/spatie/browsershot)
 
-The package can convert a webpage to an image or pdf. The conversion is done behind the scenes by [Puppeteer](https://github.com/GoogleChrome/puppeteer) which controls a headless version of Google Chrome.
+The package can convert a webpage to an image or pdf. The conversion is done behind the scenes by [Puppeteer](https://github.com/GoogleChrome/puppeteer) which controls a headless version of Google Chrome by default.
 
 Here's a quick example:
 
@@ -58,6 +58,12 @@ To use Chrome's new [headless mode](https://developers.google.com/web/updates/20
 
 ```php
 Browsershot::url('https://example.com')->newHeadless()->save($pathToImage);
+```
+
+If you prefer using Firefox, you can simply call the `useFirefox` method:
+
+```php
+Browsershot::url('https://example.com')->useFirefox()->save($pathToImage);
 ```
 
 ## Support us

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -19,6 +19,12 @@ Or you could opt to just install it globally
 npm install puppeteer --location=global
 ```
 
+You can also install the Firefox browser if you intend on using Firefox:
+
+```bash
+PUPPETEER_PRODUCT=firefox npm install puppeteer
+```
+
 ### Installing puppeteer on a Forge provisioned server
 
 On a [Forge](https://forge.laravel.com) provisioned Ubuntu server you can install the latest stable version of Chrome like this:
@@ -113,3 +119,11 @@ Browsershot::html('Foo')
   ]);
 ```
 
+### Using Firefox instead of Chrome
+
+If you need to use Firefox, you can simply call the `useFirefox` method.
+
+```php
+Browsershot::html('Foo')
+  ->useFirefox();
+```

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -120,6 +120,13 @@ class Browsershot
         return $this;
     }
 
+    public function setFirefoxPath(string $executablePath)
+    {
+        $this->setOption('executablePath', $executablePath);
+
+        return $this;
+    }
+
     public function setCustomTempPath(string $tempPath)
     {
         $this->tempPath = $tempPath;
@@ -130,6 +137,13 @@ class Browsershot
     public function post(array $postParams = [])
     {
         $this->postParams = $postParams;
+
+        return $this;
+    }
+
+    public function useFirefox()
+    {
+        $this->setOption('product', 'firefox');
 
         return $this;
     }

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -159,10 +159,37 @@ it('can take a highly customized screenshot', function () {
     expect($targetPath)->toBeFile();
 });
 
+it('can take a highly customized screenshot on firefox', function () {
+    $targetPath = __DIR__.'/temp/customScreenshot.png';
+
+    Browsershot::url('https://example.com')
+        ->useFirefox()
+        ->clip(290, 80, 700, 290)
+        ->deviceScaleFactor(2)
+        ->dismissDialogs()
+        ->mobile()
+        ->touch()
+        ->windowSize(1280, 800)
+        ->save($targetPath);
+
+    expect($targetPath)->toBeFile();
+});
+
 it('can take a screenshot of an element matching a selector', function () {
     $targetPath = __DIR__.'/temp/nodeScreenshot.png';
 
     Browsershot::url('https://example.com')
+        ->select('div')
+        ->save($targetPath);
+
+    expect($targetPath)->toBeFile();
+});
+
+it('can take a screenshot of an element matching a selector on firefox', function () {
+    $targetPath = __DIR__.'/temp/nodeScreenshot.png';
+
+    Browsershot::url('https://example.com')
+        ->useFirefox()
         ->select('div')
         ->save($targetPath);
 
@@ -178,6 +205,16 @@ it('throws an exception if the selector does not match any elements', function (
         ->save($targetPath);
 });
 
+it('throws an exception if the selector does not match any elements in firefox', function () {
+    $this->expectException(ElementNotFound::class);
+    $targetPath = __DIR__.'/temp/nodeScreenshot.png';
+
+    Browsershot::url('https://example.com')
+        ->useFirefox()
+        ->select('not-a-valid-selector')
+        ->save($targetPath);
+});
+
 it('can save a pdf by using the pdf extension', function () {
     $targetPath = __DIR__.'/temp/testPdf.pdf';
 
@@ -189,10 +226,39 @@ it('can save a pdf by using the pdf extension', function () {
     expect(mime_content_type($targetPath))->toEqual('application/pdf');
 });
 
+it('can save a pdf by using the pdf extension using firefox', function () {
+    $targetPath = __DIR__.'/temp/testPdf.pdf';
+
+    Browsershot::url('https://example.com')
+        ->useFirefox()
+        ->save($targetPath);
+
+    expect($targetPath)->toBeFile();
+
+    expect(mime_content_type($targetPath))->toEqual('application/pdf');
+});
+
 it('can save a highly customized pdf', function () {
     $targetPath = __DIR__.'/temp/customPdf.pdf';
 
     Browsershot::url('https://example.com')
+        ->hideBrowserHeaderAndFooter()
+        ->showBackground()
+        ->landscape()
+        ->margins(5, 25, 5, 25)
+        ->pages('1')
+        ->savePdf($targetPath);
+
+    expect($targetPath)->toBeFile();
+
+    expect(mime_content_type($targetPath))->toEqual('application/pdf');
+});
+
+it('can save a highly customized pdf using firefox', function () {
+    $targetPath = __DIR__.'/temp/customPdf.pdf';
+
+    Browsershot::url('https://example.com')
+        ->useFirefox()
         ->hideBrowserHeaderAndFooter()
         ->showBackground()
         ->landscape()
@@ -222,8 +288,34 @@ it('can save a highly customized pdf when using pipe', function () {
     expect(mime_content_type($targetPath))->toEqual('application/pdf');
 });
 
+it('can save a highly customized pdf when using pipe using firefox', function () {
+    $targetPath = __DIR__.'/temp/customPdf.pdf';
+
+    Browsershot::url('https://example.com')
+        ->useFirefox()
+        ->usePipe()
+        ->hideBrowserHeaderAndFooter()
+        ->showBackground()
+        ->landscape()
+        ->margins(5, 25, 5, 25)
+        ->pages('1')
+        ->savePdf($targetPath);
+
+    expect($targetPath)->toBeFile();
+
+    expect(mime_content_type($targetPath))->toEqual('application/pdf');
+});
+
 it('can return a pdf as base 64', function () {
     $base64 = Browsershot::url('https://example.com')
+        ->base64pdf();
+
+    expect(is_string($base64))->toBeTrue();
+});
+
+it('can return a pdf as base 64 using firefox', function () {
+    $base64 = Browsershot::url('https://example.com')
+        ->useFirefox()
         ->base64pdf();
 
     expect(is_string($base64))->toBeTrue();
@@ -235,6 +327,16 @@ it('can handle a permissions error', function () {
     $this->expectException(ProcessFailedException::class);
 
     Browsershot::url('https://example.com')
+        ->save($targetPath);
+});
+
+it('can handle a permissions error using firefox', function () {
+    $targetPath = '/cantWriteThisPdf.png';
+
+    $this->expectException(ProcessFailedException::class);
+
+    Browsershot::url('https://example.com')
+        ->useFirefox()
         ->save($targetPath);
 });
 

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -587,6 +587,16 @@ it('can set another chrome executable path', function () {
         ->save($targetPath);
 });
 
+it('can set another firefox executable path', function () {
+    $this->expectException(ProcessFailedException::class);
+
+    $targetPath = __DIR__.'/temp/testScreenshot.png';
+
+    Browsershot::html('Foo')
+        ->setFirefoxPath('non-existant/bin/wich/causes/an/exception')
+        ->save($targetPath);
+});
+
 it('can set another bin path', function () {
     $this->expectException(ProcessFailedException::class);
 
@@ -605,6 +615,27 @@ it('can set the include path and still works', function () {
         ->save($targetPath);
 
     expect($targetPath)->toBeFile();
+});
+
+it('can set product to firefox', function() {
+    $command = Browsershot::url('https://example.com')
+        ->useFirefox()
+        ->createScreenshotCommand('screenshot.png');
+
+    $this->assertEquals([
+        'url' => 'https://example.com',
+        'action' => 'screenshot',
+        'options' => [
+            'path' => 'screenshot.png',
+            'viewport' => [
+                'width' => 800,
+                'height' => 600,
+            ],
+            'args' => [],
+            'product' => 'firefox',
+            'type' => 'png',
+        ],
+    ], $command);
 });
 
 it('can run without sandbox', function () {


### PR DESCRIPTION
I had quite a few issues getting Chrome working in a Docker container. After a whole weekend, I decided to rather try Firefox. It worked first run. Therefor, I thought I'd add Firefox support to the Browsershot package.

It was requested here too.
https://github.com/spatie/browsershot/discussions/712 - also adds a situation where chrome doesn't work on linux :)
