### PR TITLE
[Fix] Change `screenshotQuality` property type to integer

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -40,7 +40,7 @@ class Browsershot
 
     protected string $screenshotType = 'png';
 
-    protected ?string $screenshotQuality = null;
+    protected ?int $screenshotQuality = null;
 
     protected bool $taggedPdf = false;
 


### PR DESCRIPTION
Currently, this property is defined as a nullable string. Puppeteer throws an exception when setting screenshot quality.

> Error: Expected options.quality to be a number but found string at assert (/opt/nodejs/node_modules/puppeteer-core/lib/cjs/puppeteer/util/assert.js:28:15) at CDPPage.screenshot (/opt/nodejs/node_modules/puppeteer-core/lib/cjs/puppeteer/common/Page.js:777:36)