### PR TITLE
Add global config for binaries and paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,11 @@
     ],
     "require": {
         "php": "^8.2",
-        "spatie/temporary-directory": "^2.0",
-        "symfony/process": "^6.0|^7.0",
+        "ext-fileinfo": "*",
         "ext-json": "*",
-        "ext-fileinfo": "*"
+        "spatie/laravel-package-tools": "^1.16",
+        "spatie/temporary-directory": "^2.0",
+        "symfony/process": "^6.0|^7.0"
     },
     "require-dev": {
         "pestphp/pest": "^1.20",
@@ -50,6 +51,13 @@
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Spatie\\Browsershot\\BrowsershotServiceProvider"
+            ]
         }
     }
 }

--- a/config/browsershot.php
+++ b/config/browsershot.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+
+    'node_binary' => env('BROWSERSHOT_NODE_BINARY'),
+
+    'npm_binary' => env('BROWSERSHOT_NPM_BINARY'),
+
+    'include_path' => env('BROWSERSHOT_INCLUDE_PATH'),
+
+    'node_module_path' => env('BROWSERSHOT_NODE_MODULE_PATH'),
+
+];

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -22,7 +22,7 @@ class Browsershot
 
     protected ?string $nodeModulePath = null;
 
-    protected string $includePath = '$PATH:/usr/local/bin:/opt/homebrew/bin';
+    protected ?string $includePath = null;
 
     protected ?string $binPath = null;
 
@@ -1064,7 +1064,9 @@ class Browsershot
 
     protected function getFullCommand(array $command): array|string
     {
-        $nodeBinary = $this->nodeBinary ?: 'node';
+        $nodeBinary = $this->nodeBinary
+            ?: config('browsershot.node_binary')
+            ?: 'node';
 
         $binPath = $this->binPath ?: __DIR__.'/../bin/browser.cjs';
 
@@ -1080,7 +1082,11 @@ class Browsershot
             ];
         }
 
-        $setIncludePathCommand = "PATH={$this->includePath}";
+        $includePath = $this->includePath
+            ?: config('browsershot.include_path')
+            ?: '$PATH:/usr/local/bin:/opt/homebrew/bin';
+
+        $setIncludePathCommand = "PATH={$includePath}";
 
         $setNodePathCommand = $this->getNodePathCommand($nodeBinary);
 
@@ -1094,11 +1100,16 @@ class Browsershot
 
     protected function getNodePathCommand(string $nodeBinary): string
     {
-        if ($this->nodeModulePath) {
-            return "NODE_PATH='{$this->nodeModulePath}'";
+        $nodeModulePath = $this->nodeModulePath ?: config('browsershot.node_module_path');
+
+        if ($nodeModulePath) {
+            return "NODE_PATH='{$nodeModulePath}'";
         }
-        if ($this->npmBinary) {
-            return "NODE_PATH=`{$nodeBinary} {$this->npmBinary} root -g`";
+
+        $npmBinary = $this->npmBinary ?: config('browsershot.npm_binary');
+
+        if ($npmBinary) {
+            return "NODE_PATH=`{$nodeBinary} {$npmBinary} root -g`";
         }
 
         return 'NODE_PATH=`npm root -g`';

--- a/src/BrowsershotServiceProvider.php
+++ b/src/BrowsershotServiceProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Browsershot;
+
+use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
+
+class BrowsershotServiceProvider extends PackageServiceProvider
+{
+    public function configurePackage(Package $package): void
+    {
+        $package
+            ->name('browsershot')
+            ->hasConfigFile();
+    }
+}


### PR DESCRIPTION
This PR adds the ability to globally configure the `nodeBinary`, `npmBinary`, `includePath`, and `nodeModulePath`. This is useful in a couple of scenarios:

1. If you are using Browsershot in many different environments and need easy access to globally change the binaries and paths. [See this discussion](https://github.com/spatie/browsershot/discussions/636).
2. When you are using a third-party package that is using Browsershot and don't have access to set the binaries and paths on the Browsershot call.
3. If you don't want to manually set the binaries and paths every time you are making a Browsershot call. It's also easy to forget that you have to manually set the binaries and paths to make things work.

I'm aware that this package is framework-agnostic. So I'm not quite sure how you'd like to handle this. Maybe creating a separate `laravel-browsershot` package is a better idea. 

Tests are currently failing because Laravel is missing in this context.

Let me know what you think.
