### PR TITLE
Fix generation of large PDFs

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -46,9 +46,10 @@ const getOutput = async (request, page = null) => {
         if (request.action == 'evaluate') {
             output.result = await page.evaluate(request.options.pageFunction);
         } else {
-            output.result = (
-                await page[request.action](request.options)
-            ).toString('base64');
+            const result = await page[request.action](request.options);
+
+            // Ignore output result when saving to a file
+            output.result = request.options.path ? '' : result.toString('base64');
         }
     }
 


### PR DESCRIPTION
Browsershot can not currently save PDFs that are over 512 MB.

```php
Browsershot::url('https://page-containing-large-images.com')->save('large-file.pdf');
```

The issue is described quite well here: https://github.com/microsoft/playwright/issues/14675

The error Cannot create a string longer than 0x1fffffe8 characters occurs at output.toString('base64') which can not handle very large output (see [Stack Overflow thread](https://stackoverflow.com/questions/68230031/cannot-create-a-string-longer-than-0x1fffffe8-characters-in-json-parse)).

However, we don't need to convert the output to base64 when saving PDF files to disk. If we did, we should serialize the output to buffer but I don't think this is necessary.

Fixes https://github.com/spatie/browsershot/discussions/642 and https://github.com/spatie/browsershot/discussions/745.

Note: this is the same PR as https://github.com/spatie/browsershot/pull/779 but reopened to fix the git rebase issue