### PR TITLE
Replace waitForTimeout

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -328,7 +328,7 @@ const callChrome = async pup => {
         }
 
         if (request.options.delay) {
-            await page.waitForTimeout(request.options.delay);
+            await new Promise(r => setTimeout(r, request.options.delay))
         }
 
         if (request.options.initialPageNumber) {

--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -328,7 +328,7 @@ const callChrome = async pup => {
         }
 
         if (request.options.delay) {
-            await new Promise(r => setTimeout(r, request.options.delay))
+            await new Promise(r => setTimeout(r, request.options.delay));
         }
 
         if (request.options.initialPageNumber) {


### PR DESCRIPTION
## Problem

The `page.waitForTimeout` method in Puppeteer was removed in v22. Therefore, using the `setDelay` method on a Browsershot instance will result in the following error:

```
TypeError: page.waitForTimeout is not a function
    at callChrome (.../vendor/spatie/browsershot/bin/browser.cjs:331:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

## Solution

As recommended in the [documentation for older versions of Puppeteer](https://github.com/puppeteer/puppeteer/blob/puppeteer-v21.11.0/docs/api/puppeteer.page.waitfortimeout.md), replace `page.waitForTimeout` in `browser.cjs` with `await new Promise(r => setTimeout(r, request.options.delay))`.