### PR TITLE
Support puppeteer v22

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -328,7 +328,7 @@ const callChrome = async pup => {
         }
 
         if (request.options.delay) {
-            await page.waitForTimeout(request.options.delay);
+            await new Promise(r => setTimeout(r, request.options.delay));
         }
 
         if (request.options.initialPageNumber) {


### PR DESCRIPTION
`page.waitForTimeout` is no more supported in puppeteer 22 : https://github.com/puppeteer/puppeteer/pull/11780

This PR fix this.

Related discussion : #831 