### PR TITLE
Fix redirect history test

### DIFF
--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -36,14 +36,9 @@ it('can get the redirect history', function () {
         return $item;
     }, $list);
 
-    expect($list)->toHaveCount(3);
+    expect($list)->toHaveCount(2);
 
     $this->assertEquals([
-        [
-            'url' => 'http://www.spatie.be/',
-            'status' => 301,
-            'reason' => 'Moved Permanently',
-        ],
         [
             'url' => 'https://www.spatie.be/',
             'status' => 301,


### PR DESCRIPTION
When testing the redirect history on http://www.spatie.be, the test expected 3 redirects:
1. http://www.spatie.be -> http://www.spatie.be/ (trailing "/")
2. http://www.spatie.be/ -> https://www.spatie.be/ (https)
3. https://www.spatie.be/ -> https://spatie.be/ (remove "www")

However, the first two now happen in one redirect, i.e.:
1. http://www.spatie.be -> https://www.spatie.be/ (https + trailing "/")
2. https://www.spatie.be/ -> https://spatie.be/ (remove "www")

Therefore, I altered the test to expect only two redirects instead of three.

I assume that the test failed due to a change on the spatie.be domain.