### PR TITLE
Update installation instructions for nodejs + Puppeteer

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -24,10 +24,10 @@ npm install puppeteer --location=global
 On a [Forge](https://forge.laravel.com) provisioned Ubuntu server you can install the latest stable version of Chrome like this:
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_22.x | sudo -E bash -
 sudo apt-get install -y nodejs gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libgbm-dev libxshmfence-dev
-sudo npm install --location=global --unsafe-perm puppeteer@^17
-sudo chmod -R o+rx /usr/lib/node_modules/puppeteer/.local-chromium
+sudo npm install --location=global --unsafe-perm puppeteer
+npx puppeteer browsers install chrome
 ```
 
 ### Custom node and npm binaries


### PR DESCRIPTION
I just went through the Browsershot installation process and ran into a few issues. After reading [discussion #681](https://github.com/spatie/browsershot/discussions/681) I found a pretty simple solution that uses the latest versions of nodejs and Puppeteer without locking to an [outdated version 17 of Puppeteer](https://github.com/puppeteer/puppeteer/releases/tag/v17.1.3).

The critical command seems to be

```bash
npx puppeteer browsers install chrome
```

Which I found from the following error output from Puppeteer:
```
================ Error Output: ================
Error: Could not find Chrome (ver. 123.0.6312.122). This can occur if either 1. you did not perform an installation before running the script (e.g. `npx puppeteer browsers install chrome`) or 2. your cache path is incorrectly configured (which is: /home/forge/.cache/puppeteer). For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration
```

Using the guide in this PR I was able to install Node v22, Puppeteer v22, and Chrome v123.0.6312.122, which are all the latest available version at this time.