### PR TITLE
Fixing `spatie/image`'s dependant bot alerts issues in `composer.lock`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "pestphp/pest": "^1.20",
-        "spatie/image": "^3.3",
+        "spatie/image": "^3.6",
         "spatie/phpunit-snapshot-assertions": "^4.2.3"
     },
     "autoload": {


### PR DESCRIPTION
Having installed latest `spatie/image` version, we'll avoid dependant bot alerts.