### PR TITLE
Fix save method if there are no image manipulations

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -604,7 +604,7 @@ class Browsershot
             throw CouldNotTakeBrowsershot::chromeOutputEmpty($targetPath, $output, $command);
         }
 
-        if (!$this->imageManipulations->isEmpty()) {
+        if (! $this->imageManipulations->isEmpty()) {
             $this->imageManipulations->apply($targetPath);
         }
     }

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -604,7 +604,9 @@ class Browsershot
             throw CouldNotTakeBrowsershot::chromeOutputEmpty($targetPath, $output, $command);
         }
 
-        $this->imageManipulations->apply($targetPath);
+        if (!$this->imageManipulations->isEmpty()) {
+            $this->imageManipulations->apply($targetPath);
+        }
     }
 
     public function bodyHtml(): string


### PR DESCRIPTION
After the change on this commit https://github.com/spatie/browsershot/commit/bf0307c592c981e9a725e8a62f9775fb64dfbcd3#diff-a4f3311910f99a1fe69b5fab2bcdb806288e552fe7ad5610ddb90f6a331aca37 the save method requires the spatie/image dependency even if you don't have any image manipulations.

Previously you could save an image without the need of the image dependency.

This test couldn't catch the issue because the dependency is not missing.
```
it('can take a high density screenshot', function () {
    $targetPath = __DIR__.'/temp/testScreenshot.png';

    Browsershot::url('https://example.com')
        ->deviceScaleFactor(2)
        ->save($targetPath);

    expect($targetPath)->toBeFile();
});
```