### PR TITLE
Prevent taking screenshots twice

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -709,7 +709,7 @@ class Browsershot
     {
         $requests = $this->chromiumResult?->getRequestsList();
 
-        if ($requests) {
+        if (!is_null($requests)) {
             return $requests;
         }
 
@@ -734,7 +734,7 @@ class Browsershot
     {
         $redirectHistory = $this->chromiumResult?->getRedirectHistory();
 
-        if ($redirectHistory) {
+        if (!is_null($redirectHistory)) {
             return $redirectHistory;
         }
 
@@ -756,7 +756,7 @@ class Browsershot
     {
         $messages = $this->chromiumResult?->getConsoleMessages();
 
-        if ($messages) {
+        if (!is_null($messages)) {
             return $messages;
         }
 
@@ -776,7 +776,7 @@ class Browsershot
     {
         $requests = $this->chromiumResult?->getFailedRequests();
 
-        if ($requests) {
+        if (!is_null($requests)) {
             return $requests;
         }
 
@@ -796,7 +796,7 @@ class Browsershot
     {
         $pageErrors = $this->chromiumResult?->getPageErrors();
 
-        if ($pageErrors) {
+        if (!is_null($pageErrors)) {
             return $pageErrors;
         }
 


### PR DESCRIPTION
[This request](https://spatie.be/docs/browsershot/miscellaneous-options/getting-failed-requests) currently takes 2 screenshots instead of 1 if there are no failed requests recorded:

```php
Browsershot::url('https://example.com')->failedRequests()
```

That's because `if ([/* empty array */])` returns false so Browsershot thinks the output hasn't been generated yet.

Checking for a non null value fixes this issue.