### PR TITLE
Issue with Windows temp path fixed

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -1031,7 +1031,7 @@ class Browsershot
     {
         $fullCommand = $this->getFullCommand($command);
 
-        $process = $this->isWindows() ? new Process($fullCommand) : Process::fromShellCommandline($fullCommand);
+        $process = $this->isWindows() ? new Process($fullCommand, null, $this->getWindowsEnv()) : Process::fromShellCommandline($fullCommand);
 
         $process->setTimeout($this->timeout);
 
@@ -1062,6 +1062,16 @@ class Browsershot
         }
 
         throw new ProcessFailedException($process);
+    }
+
+    protected function getWindowsEnv() : array
+    {
+        return [
+            "LOCALAPPDATA" => getenv("LOCALAPPDATA"),
+            "Path"         => getenv("Path"),
+            "SystemRoot"   => getenv("SystemRoot"),
+            "USERPROFILE"  => getenv("USERPROFILE"),
+        ];
     }
 
     protected function getFullCommand(array $command): array|string


### PR DESCRIPTION
I add the required `ENV` variables for Windows to fix the following error.

`Error: ENOENT: no such file or directory, mkdtemp 'undefined\temp\puppeteer_dev_chrome_profile-XXXXXXXXXXXX'`

It always occurs when you if don't pass these `ENV` in the `Process`
```
            "LOCALAPPDATA" => getenv("LOCALAPPDATA"),
            "Path"         => getenv("Path"),
            "SystemRoot"   => getenv("SystemRoot"),
            "USERPROFILE"  => getenv("USERPROFILE"),
```
I was inspired by [Can't get Browsershot to work on Windows with XAMPP, few different errors ](https://github.com/spatie/browsershot/discussions/728#discussioncomment-8355492)

Browsershot works fine on Linux machines, but it was a challenging task to make it work on Windows, which is finally done.

I test these and its working fine.
```
Browsershot::html('<h1>Hello World</h1>')
        ->setNodeBinary('C:\\laragon\\bin\\nodejs\\node.exe')  // Complete path to node
        ->setNpmBinary('C:\\laragon\\bin\\nodejs\\npm.cmd') // Complete path to npm
        ->setChromePath('C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe') // Complete path to chrome
        ->save('example.pdf');
```

```
Browsershot::url('https://example.com')
        ->setNodeBinary('C:\\laragon\\bin\\nodejs\\node.exe')  // Complete path to node
        ->setNpmBinary('C:\\laragon\\bin\\nodejs\\npm.cmd') // Complete path to npm
        ->setChromePath('C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe') // Complete path to chrome
        ->save('example.pdf');
```