### PR TITLE
option to disable the capturing request

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -158,9 +158,11 @@ const callChrome = async pup => {
         page.on('request', interceptedRequest => {
             var headers = interceptedRequest.headers();
 
-            requestsList.push({
-                url: interceptedRequest.url(),
-            });
+            if (request.options && request.options.disableCaptureURLS) {
+                requestsList.push({
+                    url: interceptedRequest.url(),
+                });
+            }
 
             if (request.options && request.options.disableImages) {
                 if (interceptedRequest.resourceType() === 'image') {

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -457,6 +457,11 @@ class Browsershot
         return $this->setOption('disableImages', true);
     }
 
+    public function disableCaptureURLS(): static
+    {
+        return $this->setOption('disableCaptureURLS', true);
+    }
+
     public function blockUrls($array): static
     {
         return $this->setOption('blockUrls', $array);

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -222,6 +222,27 @@ it('can disable images', function () {
     ], $command);
 });
 
+it('can disable capture urls', function () {
+    $command = Browsershot::url('https://example.com')
+        ->disableCaptureURLS()
+        ->createScreenshotCommand('screenshot.png');
+
+    $this->assertEquals([
+        'url' => 'https://example.com',
+        'action' => 'screenshot',
+        'options' => [
+            'disableCaptureURLS' => true,
+            'path' => 'screenshot.png',
+            'viewport' => [
+                'width' => 800,
+                'height' => 600,
+            ],
+            'args' => [],
+            'type' => 'png',
+        ],
+    ], $command);
+});
+
 it('can block urls', function () {
     $command = Browsershot::url('https://example.com')
         ->blockUrls([


### PR DESCRIPTION
Hi
This feature helps to reduce memory when using [data urls](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).

```php
Browsershot
    ::HTML('More data urls exists in this document'')
    ->disableCaptureURLs()
;
```