### PR TITLE
Fix - Clean up the temporary options file when browser was called successfully

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -1045,7 +1045,10 @@ class Browsershot
         $this->chromiumResult = new ChromiumResult(json_decode($rawOutput, true));
 
         if ($process->isSuccessful()) {
-            return $this->chromiumResult?->getResult();
+            $result = $this->chromiumResult?->getResult();
+
+            $this->cleanupTemporaryOptionsFile();
+            return $result;
         }
 
         $this->cleanupTemporaryOptionsFile();


### PR DESCRIPTION
## Problem
When using the option `->writeOptionsToFile()` when the PDF is successfully generated the temporary files are not removed causing the temp file to build over time eventually running out of disk space.

## Solution

When saving a PDF which internally calls the `callBrowser()` function, after retrieving the chromium result run the `$this->cleanupTemporaryOptionsFile()`.

