### PR TITLE
Add options to set protocol timeout

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -99,6 +99,7 @@ const callChrome = async pup => {
                     ...(request.options.env || {}),
                     ...process.env
                 },
+                protocolTimeout: request.options.protocolTimeout ?? 30000,
             });
         }
 

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -504,6 +504,11 @@ class Browsershot
         return $this->setOption('timeout', $timeout * 1000);
     }
 
+    public function protocolTimeout(int $protocolTimeout): static
+    {
+        return $this->setOption('protocolTimeout', $protocolTimeout * 1000);
+    }
+
     public function userAgent(string $userAgent): static
     {
         return $this->setOption('userAgent', $userAgent);


### PR DESCRIPTION
When generating large PDF, getting error:

> ProtocolError: Page.printToPDF timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.

This PR can specify `protocolTimeout()` on Browsershot. Example usage:

```php
$browsershot->protocolTimeout(60); // 60 seconds
``` 

By default the value of `protocolTimeout` is 30 seconds.