### PR TITLE
Properly convert results for Puppeteer version 23 (solves discussion #866)

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -49,7 +49,9 @@ const getOutput = async (request, page = null) => {
             const result = await page[request.action](request.options);
 
             // Ignore output result when saving to a file
-            output.result = request.options.path ? '' : result.toString('base64');
+            output.result = request.options.path
+                ? ''
+                : (result instanceof Uint8Array ? Buffer.from(result) : result).toString('base64');
         }
     }
 

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -64,6 +64,7 @@ it('can return a pdf as base 64', function () {
         ->base64pdf();
 
     expect(is_string($base64))->toBeTrue();
+    expect(base64_decode($base64, true))->toBeString();
 });
 
 it('can write options to a file and generate a pdf', function () {


### PR DESCRIPTION
Since Puppeteer 23.0.0, the result returned by Puppeteer is a Uint8Array instead of a Buffer (see https://github.com/puppeteer/puppeteer/pull/12823 and https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v23.0.0).

They state that most code should still work as Node APIs often accept Uint8Arrays. The toString method used by Browsershot requires a Buffer, so we need to convert the result to a Buffer first.

The test I've added succeeds with Puppeteer v22 and v23. In v23 it fails without the change because base64_decode returns false on an invalid base64 string, in v22 it succeeds with or without the change.

The failing tests were introduced by an earlier PR and should be fixed in https://github.com/spatie/browsershot/pull/871 or https://github.com/spatie/browsershot/pull/873

This solves this discussion: https://github.com/spatie/browsershot/discussions/866