### PR TITLE
Update handling of browser output for Puppeteer ^23.0.0

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -47,9 +47,14 @@ const getOutput = async (request, page = null) => {
             output.result = await page.evaluate(request.options.pageFunction);
         } else {
             const result = await page[request.action](request.options);
+            const resultBuffer = Buffer.from(result);
 
-            // Ignore output result when saving to a file
-            output.result = request.options.path ? '' : result.toString('base64');
+            if (request.action === 'screenshot') {
+                output.result = resultBuffer.toString('base64');
+            } else {
+                // Ignore output result when saving to a file
+                output.result = request.options.path ? '' : resultBuffer.toString();
+            }
         }
     }
 
@@ -385,7 +390,7 @@ const callChrome = async pup => {
         if (request.options.waitForSelector) {
             await page.waitForSelector(request.options.waitForSelector, (request.options.waitForSelectorOptions ? request.options.waitForSelectorOptions :  undefined));
         }
-        
+
         console.log(await getOutput(request, page));
 
         if (remoteInstance && page) {

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -674,7 +674,7 @@ class Browsershot
 
         $this->cleanupTemporaryHtmlFile();
 
-        return base64_decode($encodedPdf);
+        return $encodedPdf;
     }
 
     public function savePdf(string $targetPath)
@@ -694,11 +694,11 @@ class Browsershot
     {
         $command = $this->createPdfCommand();
 
-        $encodedPdf = $this->callBrowser($command);
+        $pdf = $this->callBrowser($command);
 
         $this->cleanupTemporaryHtmlFile();
 
-        return $encodedPdf;
+        return base64_encode($pdf);
     }
 
     public function evaluate(string $pageFunction): string


### PR DESCRIPTION
Puppeteer modified how they return stream data, for browser compatibility reasons ([#12823](https://github.com/puppeteer/puppeteer/issues/12823))
After this update, a UInt8Array byte stream is returned, instead of a Buffer.

This PR adjusts the handling of this output to be compatible with v23's output. All tests appear green, save for three which fail due to the requests list not being populated. I believe I know the cause, and will submit a PR to fix it.

Tests remain green when running Puppeteer 22.15.0 as well, so this fix should be backwards compatible with older versions that returned a Buffer rather than UInt8Array.