### PR TITLE
Correctly respond to disableCaptureURLS option

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -159,7 +159,7 @@ const callChrome = async pup => {
         page.on('request', interceptedRequest => {
             var headers = interceptedRequest.headers();
 
-            if (request.options && request.options.disableCaptureURLS) {
+            if (request.options && !request.options.disableCaptureURLS) {
                 requestsList.push({
                     url: interceptedRequest.url(),
                 });
@@ -385,7 +385,7 @@ const callChrome = async pup => {
         if (request.options.waitForSelector) {
             await page.waitForSelector(request.options.waitForSelector, (request.options.waitForSelectorOptions ? request.options.waitForSelectorOptions :  undefined));
         }
-        
+
         console.log(await getOutput(request, page));
 
         if (remoteInstance && page) {


### PR DESCRIPTION
This PR addresses a bug(?) introduced in [#861](https://github.com/spatie/browsershot/pull/861).

The option appears to be reacted to incorrectly. Perhaps the semantics should be inverted as well, i.e. change the option to "enableCaptureURLS" and enable it by default?