### PR TITLE
Fix empty PDF issue with Puppeteer ^23.0.0 

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,6 +18,9 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
+            - name: Install poppler-utils
+              run: sudo apt-get install -y poppler-utils
+
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 
 All documentation is available [on our documentation site](https://spatie.be/docs/browsershot).
 
+## Testing
+
+For running the testsuite, you'll need to have Puppeteer installed. Pleaser refer to the Browsershot requirements [here](https://spatie.be/docs/browsershot/v4/requirements). Usually `npm -g i puppeteer` will do the trick.
+
+Additionally, you'll need the `pdftotext` CLI which is part of the poppler-utils package. More info can be found in in the [spatie/pdf-to-text readme](https://github.com/spatie/pdf-to-text?tab=readme-ov-file#requirements). Usually `brew install poppler-utils` will suffice.
+
+Finally run the tests with:
+
+```bash
+composer test
+```
+
 ## Contributing
 
 Please see [CONTRIBUTING](https://github.com/spatie/.github/blob/main/CONTRIBUTING.md) for details.

--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -47,14 +47,11 @@ const getOutput = async (request, page = null) => {
             output.result = await page.evaluate(request.options.pageFunction);
         } else {
             const result = await page[request.action](request.options);
-            const resultBuffer = Buffer.from(result);
 
-            if (request.action === 'screenshot') {
-                output.result = resultBuffer.toString('base64');
-            } else {
-                // Ignore output result when saving to a file
-                output.result = request.options.path ? '' : resultBuffer.toString();
-            }
+            // Ignore output result when saving to a file
+            output.result = request.options.path
+                ? ''
+                : (result instanceof Uint8Array ? Buffer.from(result) : result).toString('base64');
         }
     }
 

--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -47,9 +47,14 @@ const getOutput = async (request, page = null) => {
             output.result = await page.evaluate(request.options.pageFunction);
         } else {
             const result = await page[request.action](request.options);
+            const resultBuffer = Buffer.from(result);
 
-            // Ignore output result when saving to a file
-            output.result = request.options.path ? '' : result.toString('base64');
+            if (request.action === 'screenshot') {
+                output.result = resultBuffer.toString('base64');
+            } else {
+                // Ignore output result when saving to a file
+                output.result = request.options.path ? '' : resultBuffer.toString();
+            }
         }
     }
 
@@ -99,6 +104,7 @@ const callChrome = async pup => {
                     ...(request.options.env || {}),
                     ...process.env
                 },
+                protocolTimeout: request.options.protocolTimeout ?? 30000,
             });
         }
 
@@ -158,7 +164,7 @@ const callChrome = async pup => {
         page.on('request', interceptedRequest => {
             var headers = interceptedRequest.headers();
 
-            if (request.options && request.options.disableCaptureURLS) {
+            if (request.options && !request.options.disableCaptureURLS) {
                 requestsList.push({
                     url: interceptedRequest.url(),
                 });
@@ -384,7 +390,7 @@ const callChrome = async pup => {
         if (request.options.waitForSelector) {
             await page.waitForSelector(request.options.waitForSelector, (request.options.waitForSelectorOptions ? request.options.waitForSelectorOptions :  undefined));
         }
-        
+
         console.log(await getOutput(request, page));
 
         if (remoteInstance && page) {

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "require-dev": {
         "pestphp/pest": "^1.20",
         "spatie/image": "^3.6",
+        "spatie/pdf-to-text": "^1.52",
         "spatie/phpunit-snapshot-assertions": "^4.2.3"
     },
     "autoload": {

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -504,6 +504,11 @@ class Browsershot
         return $this->setOption('timeout', $timeout * 1000);
     }
 
+    public function protocolTimeout(int $protocolTimeout): static
+    {
+        return $this->setOption('protocolTimeout', $protocolTimeout * 1000);
+    }
+
     public function userAgent(string $userAgent): static
     {
         return $this->setOption('userAgent', $userAgent);
@@ -669,7 +674,7 @@ class Browsershot
 
         $this->cleanupTemporaryHtmlFile();
 
-        return base64_decode($encodedPdf);
+        return $encodedPdf;
     }
 
     public function savePdf(string $targetPath)
@@ -689,11 +694,11 @@ class Browsershot
     {
         $command = $this->createPdfCommand();
 
-        $encodedPdf = $this->callBrowser($command);
+        $pdf = $this->callBrowser($command);
 
         $this->cleanupTemporaryHtmlFile();
 
-        return $encodedPdf;
+        return base64_encode($pdf);
     }
 
     public function evaluate(string $pageFunction): string

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -674,7 +674,7 @@ class Browsershot
 
         $this->cleanupTemporaryHtmlFile();
 
-        return $encodedPdf;
+        return base64_decode($encodedPdf);
     }
 
     public function savePdf(string $targetPath)
@@ -694,11 +694,11 @@ class Browsershot
     {
         $command = $this->createPdfCommand();
 
-        $pdf = $this->callBrowser($command);
+        $encodedPdf = $this->callBrowser($command);
 
         $this->cleanupTemporaryHtmlFile();
 
-        return base64_encode($pdf);
+        return $encodedPdf;
     }
 
     public function evaluate(string $pageFunction): string

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Spatie\Browsershot\Browsershot;
+use Spatie\PdfToText\Pdf;
 
 it('can save a pdf by using the pdf extension', function () {
     $targetPath = __DIR__.'/temp/testPdf.pdf';
@@ -64,6 +65,17 @@ it('can return a pdf as base 64', function () {
         ->base64pdf();
 
     expect(is_string($base64))->toBeTrue();
+});
+
+it('can return a pdf', function () {
+    $binPath = PHP_OS === 'Linux' ? '/usr/bin/pdftotext' : '/opt/homebrew/bin/pdftotext';
+    $targetPath = __DIR__.'/temp/testPdf.pdf';
+
+    $pdf = Browsershot::url('https://example.com')
+        ->pdf();
+    file_put_contents($targetPath, $pdf);
+
+    expect(Pdf::getText($targetPath, $binPath))->toContain('Example Domain');
 });
 
 it('can write options to a file and generate a pdf', function () {


### PR DESCRIPTION
This pull request reintroduces the changes done for Puppeteer v23, while fixing the issue introduced in https://github.com/spatie/browsershot/pull/870 resulting in a white PDF.

The issue was caused by not using base64 to communicate between puppeteer and Browsershot.

I also added a test that actually checks the contents of the PDF. To do this, I introduced the pdf-to-text package used in https://github.com/spatie/laravel-pdf and also added the same note in the README.

There is still one flaky test: 'can handle a permissions error with full output', which expects no errors, but sometimes gets a 404 on the favicon of example.com (because they have not favicon). It doesn't always fail, because the request for a favicon happens asynchronously.


