### PR TITLE
Added file:/ to the list of excluded paths and string contains & added option to disable redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 4.3.1 - 2024-08-30
+
+### What's Changed
+
+* Add check for `file:/` URL fetching by @JaredPage in https://github.com/spatie/browsershot/pull/xyz
+* Added the ability to disable redirects via the `disableRedirects` method by @JaredPage in https://github.com/spatie/browsershot/pull/xyz
+
+**Full Changelog**: https://github.com/spatie/browsershot/compare/4.3.0...4.3.1
+
 ## 4.3.0 - 2024-08-22
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,3 @@
-## 4.3.1 - 2024-08-30
-
-### What's Changed
-
-* Add check for `file:/` URL fetching by @JaredPage in https://github.com/spatie/browsershot/pull/xyz
-* Added the ability to disable redirects via the `disableRedirects` method by @JaredPage in https://github.com/spatie/browsershot/pull/xyz
-
-**Full Changelog**: https://github.com/spatie/browsershot/compare/4.3.0...4.3.1
-
 ## 4.3.0 - 2024-08-22
 
 ### What's Changed

--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -191,6 +191,13 @@ const callChrome = async pup => {
                 }
             }
 
+            if (request.options && request.options.disableRedirects) {
+                if (interceptedRequest.isNavigationRequest() && interceptedRequest.redirectChain().length) {
+                    interceptedRequest.abort();
+                    return
+                }
+            }
+
             if (request.options && request.options.extraNavigationHTTPHeaders) {
                 // Do nothing in case of non-navigation requests.
                 if (interceptedRequest.isNavigationRequest()) {

--- a/docs/miscellaneous-options/disabling-redirects.md
+++ b/docs/miscellaneous-options/disabling-redirects.md
@@ -1,0 +1,12 @@
+---
+title: Disabling redirects
+weight: 26
+---
+
+To avoid redirects to domains that are not allowed in your environment, or for security reasons you can disable HTTP redirects.
+
+```php
+Browsershot::url('http://www.spatie.be')
+   ->disableRedirects()
+   ...
+```

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -472,6 +472,11 @@ class Browsershot
         return $this->setOption('blockDomains', $array);
     }
 
+    public function disableRedirects(): static
+    {
+        return $this->setOption('disableRedirects', true);
+    }
+
     public function pages(string $pages): static
     {
         return $this->setOption('pageRanges', $pages);

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -257,7 +257,7 @@ class Browsershot
 
     public function setUrl(string $url): static
     {
-        if (str_starts_with(strtolower($url), 'file://')) {
+        if (str_starts_with(strtolower($url), 'file://') || str_starts_with(strtolower($url), 'file:/')) {
             throw FileUrlNotAllowed::make();
         }
 
@@ -289,7 +289,7 @@ class Browsershot
 
     public function setHtml(string $html): static
     {
-        if (str_contains(strtolower($html), 'file://')) {
+        if (str_contains(strtolower($html), 'file://') || str_contains(strtolower($html), 'file:/')) {
             throw HtmlIsNotAllowedToContainFile::make();
         }
 

--- a/src/Exceptions/FileUrlNotAllowed.php
+++ b/src/Exceptions/FileUrlNotAllowed.php
@@ -8,6 +8,6 @@ class FileUrlNotAllowed extends Exception
 {
     public static function make(): static
     {
-        return new static('An URL is not allow to start with file://');
+        return new static('An URL is not allow to start with file:// or file:/');
     }
 }

--- a/src/Exceptions/HtmlIsNotAllowedToContainFile.php
+++ b/src/Exceptions/HtmlIsNotAllowedToContainFile.php
@@ -8,6 +8,6 @@ class HtmlIsNotAllowedToContainFile extends Exception
 {
     public static function make(): static
     {
-        return new static('The specified HTML contains `file://`. This is not allowed.');
+        return new static('The specified HTML contains `file://` or `file:/`. This is not allowed.');
     }
 }

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -68,6 +68,26 @@ it('will not allow html to contain file:/', function () {
     Browsershot::html('<h1><img src="file:/" /></h1>');
 })->throws(HtmlIsNotAllowedToContainFile::class);
 
+it('no redirects - will not follow redirects', function () {
+    $targetPath = __DIR__.'/temp/redirect_fail.pdf';
+
+    Browsershot::url('http://www.spatie.be')
+        ->disableRedirects()
+        ->save($targetPath);
+
+    expect($targetPath)->not->toBeFile();
+})->throws(ProcessFailedException::class);
+
+it('no redirects - will still render direct 200 OKs', function () {
+    $targetPath = __DIR__.'/temp/redirect_success.pdf';
+
+    Browsershot::url('https://spatie.be/')
+        ->disableRedirects()
+        ->save($targetPath);
+
+    expect($targetPath)->toBeFile();
+});
+
 it('can take a high density screenshot', function () {
     $targetPath = __DIR__.'/temp/testScreenshot.png';
 

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -60,6 +60,14 @@ it('will not allow html to contain file://', function () {
     Browsershot::html('<h1><img src="file://" /></h1>');
 })->throws(HtmlIsNotAllowedToContainFile::class);
 
+it('will not allow a slightly malformed file url', function () {
+    Browsershot::url('file:/test');
+})->throws(FileUrlNotAllowed::class);
+
+it('will not allow html to contain file:/', function () {
+    Browsershot::html('<h1><img src="file:/" /></h1>');
+})->throws(HtmlIsNotAllowedToContainFile::class);
+
 it('can take a high density screenshot', function () {
     $targetPath = __DIR__.'/temp/testScreenshot.png';
 


### PR DESCRIPTION
1. There are currently checks in `src/Browsershot.php` to ensure that external linking to a file does not work, as this very easily introduces a security vulnerability. 

In this PR - I simply introduce a further check to not only check for `file://` but also for `file:/` - which also works for linking to local files alongside some tests to check this.

A straightforward POC to demonstrate this being used is:
`Browsershot::url('file:/etc/password')->save("vuln.pdf");`
Which allows the password file to be generated out as a PDF. This flaw can be further exploited to bypass the security filters and read local files from the applicationserver through the use of iFrames, leading to unauthorised access and potential data compromise.

2. There exists the ability to _not_ follow redirects in puppeteer, but this functionality isn't exposed in Browsershot. Users may not want to follow redirects for security reasons as it can lead to the download of unexpected data or information leakage such as NTLM authentication material. 

In this PR - the option to disable redirects is added alongside some tests to ensure this still works when a redirect isn't returned.

https://cwe.mitre.org/data/definitions/425.html

You would have received an email from Tanto Security regarding this - who should be credited with finding these issues.