### PR TITLE
Update setting-the-timeout.md

### DIFF
--- a/docs/miscellaneous-options/setting-the-timeout.md
+++ b/docs/miscellaneous-options/setting-the-timeout.md
@@ -10,3 +10,5 @@ Browsershot::url('https://example.com')
     ->timeout(120)
     ->save($pathToImage);
 ```
+
+If you use Browsershot in conjunction with Docker and encounter unexpected timeout errors, it may be due to the PHP_CLI_SERVER_WORKERS environment variable allowing only one worker. It might be necessary to increase the value of this variable.


### PR DESCRIPTION
At an appropriate place in the documentation, point out a potential problem with CLI server workers when Browsershot is used with Docker.

After having very confusing timeout issues while generating a lot of browsershots for a PDF document, I found an Issue and a respective comment https://github.com/spatie/browsershot/discussions/516#discussioncomment-4005642 that seems to get rid of the problem. I never experienced this problem in production so I was pretty sure it had to do with my local environment, in this case the usual culprits: node version, puppeteer version etc. Of cause I've tried different node and puppeteer versions to get rid of this annoying problem but in the end setting the `PHP_CLI_SERVER_WORKERS` (in my case to 20) reduced it to nearly none.

I didn't want to propose a specific value, since I assume my 20 workers might be total overkill but 10 weren't enough.
Since it took me a very long time to resolve this or find the root cause, i think this could spare other developers some time.

I was down the rabbit whole checking if my queue:listener restarts messed with the processes etc. just to find out that more cli server workers seem to help best.
