### PR TITLE
Add support for media features

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -250,6 +250,10 @@ const callChrome = async pup => {
             await page.emulateMediaType(request.options.emulateMedia);
         }
 
+        if (request.options && request.options.emulateMediaFeatures) {
+            await page.emulateMediaFeatures(JSON.parse(request.options.emulateMediaFeatures));
+        }
+
         if (request.options && request.options.viewport) {
             await page.setViewport(request.options.viewport);
         }

--- a/docs/miscellaneous-options/setting-the-css-media-type-of-the-page.md
+++ b/docs/miscellaneous-options/setting-the-css-media-type-of-the-page.md
@@ -11,3 +11,12 @@ Browsershot::url('https://example.com')
     ->savePdf($pathToPdf);
 ```
 
+You can also emulate [media features](https://www.w3.org/TR/mediaqueries-5/), such as dark mode or reduced motion.
+
+```php
+Browsershot::url('https://example.com')
+    ->emulateMediaFeatures([
+        ['name' => 'prefers-color-scheme', 'value' => 'dark']
+    ])
+    ->save($pathToImage);
+```

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -524,6 +524,11 @@ class Browsershot
         return $this->setOption('emulateMedia', $media);
     }
 
+    public function emulateMediaFeatures(array $features): static
+    {
+        return $this->setOption('emulateMediaFeatures', json_encode($features));
+    }
+
     public function newHeadless(): self
     {
         return $this->setOption('newHeadless', true);

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -343,6 +343,29 @@ it('can set emulate media option to null', function () {
     ], $command);
 });
 
+it('can set emulate media features', function () {
+    $command = Browsershot::url('https://example.com')
+        ->emulateMediaFeatures([
+            ['name' => 'prefers-color-scheme', 'value' => 'dark']
+        ])
+        ->createScreenshotCommand('screenshot.png');
+
+    $this->assertEquals([
+        'url' => 'https://example.com',
+        'action' => 'screenshot',
+        'options' => [
+            'path' => 'screenshot.png',
+            'viewport' => [
+                'width' => 800,
+                'height' => 600,
+            ],
+            'emulateMediaFeatures' => '[{"name":"prefers-color-scheme","value":"dark"}]',
+            'args' => [],
+            'type' => 'png',
+        ],
+    ], $command);
+});
+
 it('can use pipe', function () {
     $command = Browsershot::url('https://example.com')
         ->usePipe()


### PR DESCRIPTION
This introduces support for the [emulateMediaFeatures](https://pptr.dev/api/puppeteer.page.emulatemediafeatures) API as passing these to `emulateMediaType` is no longer supported.

It allows users to define any of the media query features [added in level 5](https://www.w3.org/TR/mediaqueries-5/), for example, enabling dark mode and reduced motion:

```php
Browsershot::url('https://example.com')
    ->emulateMediaFeatures([
        ['name' => 'prefers-color-scheme', 'value' => 'dark'],
        ['name' => 'prefers-reduced-motion', 'value' => 'reduce']
    ])
    ->save($pathToImage);
```