### PR TITLE
Update obsolete devices API

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -241,7 +241,7 @@ const callChrome = async pup => {
         }
 
         if (request.options && request.options.device) {
-            const devices = puppet.devices;
+            const devices = puppet.KnownDevices;
             const device = devices[request.options.device];
             await page.emulate(device);
         }


### PR DESCRIPTION
This PR updates the API to the recommended [KnownDevices](https://pptr.dev/api/puppeteer.knowndevices).

It seems this was marked as obsolete in [v21.11.0](https://github.com/puppeteer/puppeteer/blob/puppeteer-v21.11.0/docs/api/puppeteer.devices.md) and removed in [v22.0.0](https://github.com/puppeteer/puppeteer/blob/puppeteer-v22.0.0/docs/api/puppeteer.devices.md).

I couldn't find any minimum version in this repo's requirements for puppeteer, but this will break support for older versions.