### PR TITLE
Fix await browser close

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -394,14 +394,14 @@ const callChrome = async pup => {
             await page.close();
         }
 
-        await remoteInstance ? browser.disconnect() : browser.close();
+        await (remoteInstance ? browser.disconnect() : browser.close());
     } catch (exception) {
         if (browser) {
             if (remoteInstance && page) {
                 await page.close();
             }
 
-            (await remoteInstance) ? browser.disconnect() : browser.close();
+            await (remoteInstance ? browser.disconnect() : browser.close());
         }
 
         const output = await getOutput(request);


### PR DESCRIPTION
`remoteInstance` is a boolean while `disconnect()`and `close()` return promises.

The default behavior of `await remoteInstance ? browser.disconnect() : browser.close()` without parenthesis is to await the boolean which will resolve instantly.

Adding parenthesis ensures the promises are "awaited" properly.