### PR TITLE
Add PDF fullPage support

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -878,6 +878,13 @@ class Browsershot
             $command['options']['scale'] = $this->scale;
         }
 
+        if ($this->additionalOptions['fullPage'] ?? false) {
+            $heightPx = $this->callBrowser($this->createCommand($url, 'evaluate', ['pageFunction' => 'document.body.scrollHeight']));
+            $widthPx = $this->callBrowser($this->createCommand($url, 'evaluate', ['pageFunction' => 'document.body.scrollWidth']));
+            $command['options']['height'] = $heightPx;
+            $command['options']['width'] = $widthPx;
+        }
+
         return $command;
     }
 


### PR DESCRIPTION
The fullPage option does not work by default when creating a PDF. This change will force the command to manually evaluate the width and height of the page before creating the PDF. It has its flaws (when document.body is not the scrollable element for example), but it will cover 99% of the cases.

Let me know if it requires changing in any way or if you're not interested at all in this.