### PR TITLE
Fixed `ignoreHttpsErrors()` method

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -73,7 +73,7 @@ const callChrome = async pup => {
         if (request.options.remoteInstanceUrl || request.options.browserWSEndpoint ) {
             // default options
             let options = {
-                ignoreHTTPSErrors: request.options.ignoreHttpsErrors
+                acceptInsecureCerts: request.options.acceptInsecureCerts
             };
 
             // choose only one method to connect to the browser instance
@@ -93,7 +93,7 @@ const callChrome = async pup => {
         if (!browser) {
             browser = await puppet.launch({
                 headless: request.options.newHeadless ? 'new' : true,
-                ignoreHTTPSErrors: request.options.ignoreHttpsErrors,
+                acceptInsecureCerts: request.options.acceptInsecureCerts,
                 executablePath: request.options.executablePath,
                 args: request.options.args || [],
                 pipe: request.options.pipe || false,

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -407,7 +407,7 @@ class Browsershot
 
     public function ignoreHttpsErrors(): static
     {
-        return $this->setOption('ignoreHttpsErrors', true);
+        return $this->setOption('acceptInsecureCerts', true);
     }
 
     public function mobile(bool $mobile = true): static

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -306,7 +306,7 @@ it('can ignore https errors', function () {
         'url' => 'https://example.com',
         'action' => 'screenshot',
         'options' => [
-            'ignoreHttpsErrors' => true,
+            'acceptInsecureCerts' => true,
             'path' => 'screenshot.png',
             'viewport' => [
                 'width' => 800,


### PR DESCRIPTION
With the release of [Puppeteer v23](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v23.0.0) the `ignoreHttpsErrors` was renamed to [`acceptInsecureCerts`](https://pptr.dev/api/puppeteer.browserconnectoptions/#acceptinsecurecerts).

Updated the `ignoreHttpsErrors()` method to use the new `acceptInsecureCerts` option.