### PR TITLE
Support old headless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ foreach ($requests as $request) {
 }
 ```
 
-To use Chrome's new [headless mode](https://developers.google.com/web/updates/2017/04/headless-chrome) pass the `newHeadless` method:
+To use Chrome's old [headless mode](https://developer.chrome.com/docs/chromium/headless), also known as `chrome-headless-shell`, pass the `oldHeadless` method:
 
 ```php
-Browsershot::url('https://example.com')->newHeadless()->save($pathToImage);
+Browsershot::url('https://example.com')->oldHeadless()->save($pathToImage);
 ```
 
 ## Support us

--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -92,7 +92,7 @@ const callChrome = async pup => {
 
         if (!browser) {
             browser = await puppet.launch({
-                headless: request.options.newHeadless ? 'new' : true,
+                headless: request.options.oldHeadless ? 'shell' : true,
                 acceptInsecureCerts: request.options.acceptInsecureCerts,
                 executablePath: request.options.executablePath,
                 args: request.options.args || [],

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -546,9 +546,9 @@ class Browsershot
         return $this->setOption('emulateMediaFeatures', json_encode($features));
     }
 
-    public function newHeadless(): self
+    public function oldHeadless(): self
     {
-        return $this->setOption('newHeadless', true);
+        return $this->setOption('oldHeadless', true);
     }
 
     public function windowSize(int $width, int $height): static

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1001,14 +1001,14 @@ it('can set the custom temp path', function () {
     expect('application/pdf')->toEqual($mimeType);
 });
 
-it('should set the new headless flag when using the new method', function () {
-    $command = Browsershot::url('https://example.com')->newHeadless()->createScreenshotCommand('screenshot.png');
+it('should set the old headless flag when using the old method', function () {
+    $command = Browsershot::url('https://example.com')->oldHeadless()->createScreenshotCommand('screenshot.png');
 
     $this->assertEquals([
         'url' => 'https://example.com',
         'action' => 'screenshot',
         'options' => [
-            'newHeadless' => true,
+            'oldHeadless' => true,
             'type' => 'png',
             'path' => 'screenshot.png',
             'args' => [],


### PR DESCRIPTION
Since Puppeteer v22, `newHeadless` is now the default. See: https://pptr.dev/guides/headless-modes

So I replaced the method `newHeadless` (which is now useless) with `oldHeadless` to use the old `chrome-headless-shell`.