### PR TITLE
support `chrome-headless-shell` (old headless mode)

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -92,7 +92,7 @@ const callChrome = async pup => {
 
         if (!browser) {
             browser = await puppet.launch({
-                headless: request.options.newHeadless ? 'new' : true,
+                headless: request.options.newHeadless ? true : 'shell',
                 acceptInsecureCerts: request.options.acceptInsecureCerts,
                 executablePath: request.options.executablePath,
                 args: request.options.args || [],


### PR DESCRIPTION
https://github.com/spatie/browsershot/blob/02d17646ce0db9eafe923c6149de4da97808232a/bin/browser.cjs#L95

In current Puppeteer versions (v22+ according to the docs), `{headless: true}` actually launches the new headless mode, while `{headless: 'shell'}` launches the old mode:
- https://pptr.dev/guides/headless-modes

This makes it currently impossible to use the old headless mode with Browsershot, which is our preferred mode for creating PDFs, and the only mode that, in our experience, actually works with Basic Auth.

See https://developer.chrome.com/blog/chrome-headless-shell for more details.

---

Note: We were previously able to work around this issue by enabling the old headless mode the following way instead:

```php
$browsershot->addChromiumArguments([
    'headless' => 'old', // see https://developer.chrome.com/docs/chromium/headless#use_old_headless_mode
]);
```

As of [Puppeteer v24.1.0](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v24.1.0), this workaround unfortunately does not work anymore, as `old` is not a valid option anymore:

```
================ Error Output: ================
sh: npm: command not found Error: Failed to launch the browser process!

Old Headless mode has been removed from the Chrome binary. Please use the 
new Headless mode (https://developer.chrome.com/docs/chromium/new-headless)
or the chrome-headless-shell which is a standalone implementation of the old
Headless mode (https://developer.chrome.com/blog/chrome-headless-shell).

TROUBLESHOOTING: https://pptr.dev/troubleshooting
```