### PR TITLE
run-tests: disable app armor restrictions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,6 +36,9 @@ jobs:
             - name: Install dependencies
               run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
+            - name: Disable AppArmor
+              run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+
             - name: Install Puppeteer
               run: npm install puppeteer
 


### PR DESCRIPTION
Should fix the `No usable sandbox!` error as seen in https://github.com/spatie/browsershot/actions/runs/13367517414, via https://github.com/puppeteer/puppeteer/pull/13196. Tests still fail with this, but for different reasons.