### PR TITLE
Apply selector after wait for selector/function instead of before

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -367,6 +367,18 @@ const callChrome = async pup => {
             }, request.options.initialPageNumber);
         }
 
+        if (request.options.function) {
+            let functionOptions = {
+                polling: request.options.functionPolling,
+                timeout: request.options.functionTimeout || request.options.timeout
+            };
+            await page.waitForFunction(request.options.function, functionOptions);
+        }
+
+        if (request.options.waitForSelector) {
+            await page.waitForSelector(request.options.waitForSelector, (request.options.waitForSelectorOptions ? request.options.waitForSelectorOptions :  undefined));
+        }
+
         if (request.options.selector) {
             var element;
             const index = request.options.selectorIndex || 0;
@@ -385,18 +397,6 @@ const callChrome = async pup => {
             }
 
             request.options.clip = await element.boundingBox();
-        }
-
-        if (request.options.function) {
-            let functionOptions = {
-                polling: request.options.functionPolling,
-                timeout: request.options.functionTimeout || request.options.timeout
-            };
-            await page.waitForFunction(request.options.function, functionOptions);
-        }
-
-        if (request.options.waitForSelector) {
-            await page.waitForSelector(request.options.waitForSelector, (request.options.waitForSelectorOptions ? request.options.waitForSelectorOptions :  undefined));
         }
 
         console.log(await getOutput(request, page));


### PR DESCRIPTION
Browsershot includes the ability to clip the exported image to a specific element using a `selector` option, as well as a `waitForSelector` option to wait until a certain selector appears on the page. It seems pretty useful to use these options together, eg:

```php
$browsershot
    ->waitForSelector('.export-target') // Wait until ".export-target" element appears on the page.
    ->selector('.export-target') // Only include that element in the screenshot
    ->save();
```

This is currently *not* possible, as the puppeteer script processes the `selector` option *before* `waitForSelector`.

This PR simply changes the order of how the options are processed, so the `selector` option is processed *after* `waitForSelector` and `waitForFunction`.