### PR TITLE
Fix handling of page errors with value `null`

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -133,8 +133,8 @@ const callChrome = async pup => {
 
         page.on('pageerror', (msg) => {
             pageErrors.push({
-                name: msg.name || 'unknown error',
-                message: msg.message || msg.toString(),
+                name: msg?.name || 'unknown error',
+                message: msg?.message || msg?.toString() || 'null'
             });
         });
 

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -1075,6 +1075,22 @@ it('should be able to fetch page errors with pageErrors method', function () {
     expect($errors[0]['message'])->toBeString();
 });
 
+it('should be able to fetch page errors with pageErrors method when the page throws null', function () {
+    $errors = Browsershot::html('<!DOCTYPE html>
+    <html lang="en">
+      <body>
+        <script type="text/javascript">
+            throw null;
+        </script>
+      </body>
+    </html>')->pageErrors();
+
+    expect($errors)->toBeArray();
+    expect(count($errors))->toBe(1);
+    expect($errors[0]['name'])->toBeString();
+    expect($errors[0]['message'])->toBeString();
+});
+
 it('will apply manipulations when taking screenshots', function () {
     $screenShot = Browsershot::url('https://example.com')
         ->windowSize(1920, 1080)


### PR DESCRIPTION
Some pages may throw `null` as error. This leads to TypeError when collecting the page errors information. Set "null" as the message in such cases as there is no other meaningful value.