### PR TITLE
Enable click with non-CSS selectors

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -337,6 +337,17 @@ const callChrome = async pup => {
             }
         }
 
+        if (request.options && request.options.locatorClicks) {
+            for (let i = 0, len = request.options.locatorClicks.length; i < len; i++) {
+                let clickOptions = request.options.locatorClicks[i];
+                await page.locator(clickOptions.selector).click({
+                    'button': clickOptions.button,
+                    'clickCount': clickOptions.clickCount,
+                    'delay': clickOptions.delay,
+                });
+            }
+        }        
+
         if (request.options && request.options.addStyleTag) {
             await page.addStyleTag(JSON.parse(request.options.addStyleTag));
         }

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -214,6 +214,17 @@ class Browsershot
         return $this;
     }
 
+    public function locatorClick(string $selector, string $button = 'left', int $clickCount = 1, int $delay = 0): static
+    {
+        $locatorClicks = $this->additionalOptions['locatorClicks'] ?? [];
+
+        $locatorClicks[] = compact('selector', 'button', 'clickCount', 'delay');
+
+        $this->setOption('locatorClicks', $locatorClicks);
+
+        return $this;
+    }
+
     public function selectOption(string $selector, string $value = ''): static
     {
         $dropdownSelects = $this->additionalOptions['selects'] ?? [];


### PR DESCRIPTION
Hello,

As I wrote in thread #947, Puppeteer allows for additional selectors beyond CSS. These can be very useful for clicks, especially those for cookie consent where the CSS classes are not static (did someone mention Facebook)?

This little PR adds a `locatorClick()` method that allows clicking on the page using non-CSS selectors (https://pptr.dev/guides/page-interactions#non-css-selectors). I thought I'd use a new method to make the change backwards compatible with those who already use `click()` without causing problems.

I'm already using it in production with success.

Thanks

Ciao