### PR TITLE
Deny Arbitrary Local File Read Bypasses

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -76,6 +76,8 @@ class Browsershot
         'file:\\',
         'file:\\\\',
         'view-source',
+        '\\\\',
+        '//'
     ];
 
     /** @var array<string,string> */


### PR DESCRIPTION
Earlier versions allowed HTML tags to access and read arbitrary local files using payloads such as `<iframe src="\\localhost/etc/passwd">` or `<iframe src="//127.0.0.1/etc/passwd">`. This new array in "$unsafeProtocols" deny this type of exploitation.