### PR TITLE
Fix #970: Block local file read bypasses via UNC paths and protocol-relative URLs

### DIFF
--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -76,6 +76,7 @@ class Browsershot
         'file:\\',
         'file:\\\\',
         'view-source',
+        '\\\\',
     ];
 
     /** @var array<string,string> */
@@ -339,6 +340,10 @@ class Browsershot
                 if (str_contains(strtolower($content), $protocol)) {
                     throw HtmlIsNotAllowedToContainFile::make();
                 }
+            }
+
+            if (preg_match('#//\s*(localhost[/:\s]|127\.|0\.0\.0\.0[/:\s]|\[::1][/:\s]|::1[/:\s])#i', $content)) {
+                throw HtmlIsNotAllowedToContainFile::make();
             }
         }
 

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -74,6 +74,29 @@ it('will not allow html to contain file:/', function () {
     Browsershot::html('<h1><img src="file:/" /></h1>');
 })->throws(HtmlIsNotAllowedToContainFile::class);
 
+it('will not allow html to contain UNC paths', function (string $html) {
+    Browsershot::html($html);
+})->throws(HtmlIsNotAllowedToContainFile::class)->with([
+    '<iframe src="\\\\localhost/etc/passwd">',
+    '<iframe src="\\\\127.0.0.1/etc/passwd">',
+]);
+
+it('will not allow html to contain protocol-relative urls to local addresses', function (string $html) {
+    Browsershot::html($html);
+})->throws(HtmlIsNotAllowedToContainFile::class)->with([
+    '<iframe src="//localhost/etc/passwd">',
+    '<iframe src="//127.0.0.1/etc/passwd">',
+    '<iframe src="//127.1.2.3/etc/passwd">',
+    '<iframe src="//0.0.0.0/etc/passwd">',
+    '<iframe src="//[::1]/etc/passwd">',
+]);
+
+it('will allow html with legitimate protocol-relative urls', function () {
+    $browsershot = Browsershot::html('<link href="//cdn.example.com/style.css">');
+
+    expect($browsershot)->toBeInstanceOf(Browsershot::class);
+});
+
 it('no redirects - will not follow redirects', function () {
     $targetPath = __DIR__.'/temp/redirect_fail.pdf';
 


### PR DESCRIPTION
## Summary

Addresses the security issue raised in #970 (local file read via `\\localhost/...` and `//127.0.0.1/...` bypasses), but with a corrected approach:

- **UNC paths**: Added `\\` to `unsafeProtocols`, blocking HTML containing double-backslash patterns like `<iframe src="\\localhost/etc/passwd">`
- **Protocol-relative local URLs**: Added a targeted regex in `setHtml()` that blocks `//` followed by local addresses (localhost, 127.x.x.x, 0.0.0.0, [::1])

### Why not just add `//` to `unsafeProtocols`?

The original PR #970 added `//` to the `unsafeProtocols` array. This would break `setHtml()` completely because the check uses `str_contains()` — every HTML document with a URL like `https://example.com` contains `//`. The regex approach targets only local addresses while allowing legitimate protocol-relative URLs like `//cdn.example.com/style.css`.

## Test plan
- [x] Tests for UNC path payloads (`\\localhost`, `\\127.0.0.1`)
- [x] Tests for protocol-relative local URLs (`//localhost`, `//127.x.x.x`, `//0.0.0.0`, `//[::1]`)
- [x] Test that legitimate protocol-relative URLs still work
- [x] All existing tests pass (116 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)