### PR TITLE
Update requirements.md

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -35,7 +35,12 @@ npx puppeteer browsers install chrome
 
 # Install dependencies
 sudo apt update
-sudo apt install libx11-xcb1 libxcomposite1 libasound2t64 libatk1.0-0 libatk-bridge2.0-0 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 
+sudo apt install libx11-xcb1 libxcomposite1 libasound2t64 libatk1.0-0 libatk-bridge2.0-0 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6
+
+# You may get an error: "No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor"
+# You can fix this by editing /etc/syscntl.conf and add these lines to the end of the file
+kernel.apparmor_restrict_unprivileged_userns=0
+kernel.apparmor_restrict_unprivileged_unconfined=0
 ```
 If you are using Ubuntu v22.04, replace `libasound2t64` by `libasound2`
 


### PR DESCRIPTION
On Ubuntu 24.04, namespace restrictions cause this error:

`No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor`

This can be fixed by adding two lines to `/etc/syscntl.conf`.

References:
- [Laracsts](https://laracasts.com/discuss/channels/laravel/laravel-pdf-spatie-puppeteer-forge-no-usable-sandbox-error-in-production)
- [AskUbuntu](https://askubuntu.com/questions/1545324/solved-ubuntu-24-04-broke-sandboxing-how2-fix)