### PR TITLE
feat: Add evaluateOnNewDocument support

### DIFF
--- a/bin/browser.cjs
+++ b/bin/browser.cjs
@@ -333,6 +333,10 @@ const callChrome = async pup => {
             await page.setDefaultNavigationTimeout(options.timeout);
         }
 
+        if (options.evaluateOnNewDocument) {
+            await page.evaluateOnNewDocument(options.evaluateOnNewDocument);
+        }
+
         const requestOptions = {};
 
         if (options.networkIdleTimeout) {

--- a/src/Browsershot.php
+++ b/src/Browsershot.php
@@ -287,6 +287,11 @@ class Browsershot
         return $this;
     }
 
+    public function evaluateOnNewDocument(string $pageFunction): static
+    {
+        return $this->setOption('evaluateOnNewDocument', $pageFunction);
+    }
+
     public function setUrl(string $url): static
     {
         $url = trim($url);

--- a/tests/BrowsershotTest.php
+++ b/tests/BrowsershotTest.php
@@ -689,6 +689,35 @@ it('can evaluate page', function () {
     expect($result)->toEqual('2');
 });
 
+it('can evaluate script on new document before page loads', function () {
+    $result = Browsershot::url('https://example.com')
+        ->evaluateOnNewDocument('window.__injected = 42')
+        ->evaluate('window.__injected');
+
+    expect($result)->toEqual('42');
+});
+
+it('can set evaluateOnNewDocument option', function () {
+    $command = Browsershot::url('https://example.com')
+        ->evaluateOnNewDocument('() => { window.__testVar = true; }')
+        ->createScreenshotCommand('screenshot.png');
+
+    $this->assertEquals([
+        'url' => 'https://example.com',
+        'action' => 'screenshot',
+        'options' => [
+            'path' => 'screenshot.png',
+            'viewport' => [
+                'width' => 800,
+                'height' => 600,
+            ],
+            'args' => [],
+            'type' => 'png',
+            'evaluateOnNewDocument' => '() => { window.__testVar = true; }',
+        ],
+    ], $command);
+});
+
 it('can add a timeout to puppeteer', function () {
     $command = Browsershot::url('https://example.com')
         ->timeout(123)


### PR DESCRIPTION
## Summary

- Adds `evaluateOnNewDocument(string $pageFunction)` to `Browsershot.php`, allowing users to inject JavaScript that runs **before** any page scripts execute via Puppeteer's `page.evaluateOnNewDocument()`
- Hooks into `bin/browser.cjs` before `page.goto()` so the script is guaranteed to run before page load
- Useful for stubbing globals, injecting polyfills, overriding `navigator.webdriver`, or disabling analytics before navigation

## Usage

```php
Browsershot::url('https://example.com')
    ->evaluateOnNewDocument('window.__myFlag = true')
    ->save('/path/to/screenshot.png');
```

## Changes

- `bin/browser.cjs` — evaluate the script before `page.goto()`
- `src/Browsershot.php` — fluent `evaluateOnNewDocument()` method via `setOption()`
- `tests/BrowsershotTest.php` — command structure test and behavioral test confirming script runs before page load

## Test plan

- [x] Command test verifies option flows into generated command JSON
- [x] Behavioral test injects a global via `evaluateOnNewDocument` and reads it back with `evaluate`
- [x] All existing tests unaffected

Refs #977