### PR TITLE
Fix typo in sysctl configuration instructions

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -38,7 +38,7 @@ sudo apt update
 sudo apt install libx11-xcb1 libxcomposite1 libasound2t64 libatk1.0-0 libatk-bridge2.0-0 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6
 
 # You may get an error: "No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor"
-# You can fix this by editing /etc/syscntl.conf and add these lines to the end of the file
+# You can fix this by editing /etc/sysctl.conf and add these lines to the end of the file
 kernel.apparmor_restrict_unprivileged_userns=0
 kernel.apparmor_restrict_unprivileged_unconfined=0
 ```


### PR DESCRIPTION
Corrected the file path from '/etc/syscntl.conf' to '/etc/sysctl.conf' in the requirements documentation.